### PR TITLE
Add missing condition check

### DIFF
--- a/deployment/rpm/about.md
+++ b/deployment/rpm/about.md
@@ -58,7 +58,7 @@ project, including configuration, build, internationalization, help files, etc.
 
 %build
 %configure
-make %{_smp_mflags}
+make %{?_smp_mflags}
 
 %install
 %make_install


### PR DESCRIPTION
The make statement is supposed to be `make %{?_smp_mflags}` since it's potentially not always defined.

See complete hello.spec here: https://fedoraproject.org/wiki/How_to_create_a_GNU_Hello_RPM_package#A_complete_hello.spec_file