### PR TITLE
Add content to build application for Secondary Architetcures

### DIFF
--- a/deployment/secondary_architectures/about.md
+++ b/deployment/secondary_architectures/about.md
@@ -1,0 +1,62 @@
+---
+title: Secondary Architectures
+subsection: secondary_architectures
+section: deployment
+description: Building your application for architectures like s390(x), PowerPC, ARMv8
+---
+
+# Secondary Architectures
+In Fedora, we call s390(x), PowerPC and ARMv8 architectures as [Secondary Architectures](https://fedoraproject.org/wiki/Architectures#Secondary_Architectures). These are either not easily accessible or newly introduced as compared to [Primary Acrhitectures](https://fedoraproject.org/wiki/Architectures#Secondary_Architectures)
+
+## Benefits
+
+Developers generally have an Intel (i686/x86_64) based machine, so they can build and test their applications for that. A successful build and run of an application on one architecture (e.g. x86_64) doesn't ensure that it will compile and run successfully on other architectures (e.g. PowerPC) too. This is because behaviours like endianness, instruction set etc may vary by architectures. A developer can use Fedora Secondary architectures infrastructure to ensure that her application builds successfully on machines like PowerPC. This helps to make your application available to even larger audience.
+
+## Pre-requisites
+
+In Fedora, every application is shipped in [rpm](http://www.rpm.org/) format, which is also required to build an application using Fedora infrastructure. Most applications which meet [Fedora packaging licensing](https://fedoraproject.org/wiki/Packaging:Guidelines?rd=Packaging/Guidelines#Licensing) will be already available in Fedora.
+
+Make sure you first follow below checklist before you start building your application using Fedora infrastructure:
+
+* Check if rpm package of application is already [available in Fedora](https://apps.fedoraproject.org/packages/). If it is not packaged then please follow [RPM Packaging](https://developer.fedoraproject.org/deployment/rpm/about.html) guide to create one.
+* Create a [Fedora Account System (FAS)](https://admin.fedoraproject.org/accounts) account and follow [basic process](https://fedoraproject.org/wiki/Join_the_package_collection_maintainers?rd=PackageMaintainers/Join#Create_a_Fedora_Account)
+* Now, [create certificate](https://fedoraproject.org/wiki/Using_the_Koji_build_system#Fedora_Account_System_.28FAS2.29_Setup) in order to do build in [koji](https://fedoraproject.org/wiki/Koji) for available architetcures.
+
+## Example
+
+The following example (iprutils package) will demonstrate how to get an rpm package available in Fedora repository:
+
+````
+# Clone existing package available in Fedora repository e.g. iprutils
+$ fedpkg clone -a iprutils && cd iprutils && ls
+   0001-Service-start-is-controled-by-udev-rule.patch  iprdbg.8.gz  iprutils.spec  sources
+
+# Fetch latest source available in Fedora repo for application iprutils
+$ fedpkg sources && ls
+   0001-Service-start-is-controled-by-udev-rule.patch  iprdbg.8.gz  iprutils  iprutils-2.4.11.1.tar.gz  sources
+
+# Generates source rpm (*.src.rpm) for iprutils which we will use in ppc-koji to build
+$ fedpkg srpm
+  0001-Service-start-is-controled-by-udev-rule.patch  iprdbg.8.gz  iprutils-2.4.11.1-1.fc25.src.rpm  iprutils-2.4.11.1.tar.gz  iprutils.spec  sources
+
+````
+
+Further, to modify source or spec file follow below steps:
+
+````
+# Create required directory structure in ~/rpmbuild/
+$ rpmbuild-setuptree
+
+# Copy original or modified spec file in ~/rpmbuild/SPECS/ directory
+$ cp 0001-Service-start-is-controled-by-udev-rule.patch ~/rpmbuild/SOURCES/
+$ cp iprdbg.8.gz ~/rpmbuild/SOURCES
+$ cp *.tar.gz ~/rpmbuild/SOURCES
+$ cp iprutils.spec ~/rpmbuild/SOURCES/
+
+# Create srpm file
+$ rpmbuild -bs ~/rpmbuild/SOURCES/iprutils.spec
+
+````
+Generated srpm will be available in ~/rpmbuild/SRPMS/ directory
+
+**Note:** iprutils package which is used as an example may get updated later on and hence content may change.

--- a/deployment/secondary_architectures/about.md
+++ b/deployment/secondary_architectures/about.md
@@ -3,6 +3,8 @@ title: Secondary Architectures
 subsection: secondary_architectures
 section: deployment
 description: Building your application for architectures like s390(x), PowerPC, ARMv8
+
+order: 1
 ---
 
 # Secondary Architectures
@@ -26,7 +28,7 @@ Make sure you first follow below checklist before you start building your applic
 
 The following example (iprutils package) will demonstrate how to get an rpm package available in Fedora repository:
 
-````
+```
 # Clone existing package available in Fedora repository e.g. iprutils
 $ fedpkg clone -a iprutils && cd iprutils && ls
    0001-Service-start-is-controled-by-udev-rule.patch  iprdbg.8.gz  iprutils.spec  sources
@@ -39,11 +41,11 @@ $ fedpkg sources && ls
 $ fedpkg srpm
   0001-Service-start-is-controled-by-udev-rule.patch  iprdbg.8.gz  iprutils-2.4.11.1-1.fc25.src.rpm  iprutils-2.4.11.1.tar.gz  iprutils.spec  sources
 
-````
+```
 
 Further, to modify source or spec file follow below steps:
 
-````
+```
 # Create required directory structure in ~/rpmbuild/
 $ rpmbuild-setuptree
 
@@ -56,7 +58,7 @@ $ cp iprutils.spec ~/rpmbuild/SOURCES/
 # Create srpm file
 $ rpmbuild -bs ~/rpmbuild/SOURCES/iprutils.spec
 
-````
+```
 Generated srpm will be available in ~/rpmbuild/SRPMS/ directory
 
 **Note:** iprutils package which is used as an example may get updated later on and hence content may change.

--- a/deployment/secondary_architectures/powerpc.md
+++ b/deployment/secondary_architectures/powerpc.md
@@ -2,6 +2,7 @@
 title: PowerPC
 subsection: secondary_architectures
 
+order: 2
 ---
 
 # PowerPC
@@ -14,9 +15,9 @@ PowerPC supports both little and big endian modes and can even switch from one m
 
 To initiate a build for PowerPC, use ppc-koji command:
 
-````
+```
 ppc-koji --scratch build rawhide srpm_pkg1
-````
+```
 
 The above command will start a scratch build of package srpm_pkg1 against Fedora rawhide for ppc64 and ppc64le architectures. Use "ppc-koji \-\-help" in console to see all available options.
 
@@ -24,45 +25,40 @@ To build against other Fedora branches (e.g. F23, F24), specify specific branch 
 
 ```
 ppc-koji --scratch build F24 srpm_pkg1
-````
+```
 
 If the application is only meant to run on PowerPC, specify ExclusiveArch tag in [RPM spec file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
 
-````
+```
 ExclusiveArch:  ppc64 ppc64le
-````
+```
 
 ## Example
 
 In Secondary Architectures section, we saw how to get/create iprutils srpm as an example. Now, you already have srpm (src.rpm) file of iprutils.
 The following example will demonstrate how to build an application for PowerPC architecture from srpm:
 
-````
+```
 # Initiate iprutils package build for PowerPC architecture
 $ ppc-koji build --scratch rawhide iprutils-2.4.11.1-1.fc25.src.rpm
   Created task: 3298139
   Task info: http://ppc.koji.fedoraproject.org/koji/taskinfo?taskID=3298139
   ....
 
-````
+```
 For each build, a Task ID is created in ppc koji. You can see build status and it's log by going to the url provided in Task info.
 
 ## Viewing koji builds
 
 Builds specific to ppc64(le) are hosted at [http://ppc.koji.fedoraproject.org/](http://ppc.koji.fedoraproject.org/). UI is very similar to [primary koji](http://koji.fedoraproject.org/).
 
-## Getting access to a powerpc machine
-
-It is possible that to fix/test some issues/features in ppc64(le) quickly, you may require access to a ppc64(le) machine. You can request to:
-
-- Brent Baude - Either email him at <bbaude@redhat.com> or find him on freenode with IRC nick rangerpb
-- [Karsten Hopp](https://fedoraproject.org/wiki/User:Karsten) - Either email him at <karsten@redhat.com> or ask him on frenode with IRC nick kick_ or karsten
 
 ## Reaching out for help
 If you face any difficulty reach out to us for help:
 
 - On freenode IRC channel [#fedora-ppc](https://webchat.freenode.net/?channels=#fedora-ppc)
 - Send an email to <ppc@lists.fedoraproject.org> mailing list
+- Get [ppc64(le) machine access](https://fedoraproject.org/wiki/Architectures/PowerPC#PPC_Shell_access_for_debugging)
 
 ## More documentation
 

--- a/deployment/secondary_architectures/powerpc.md
+++ b/deployment/secondary_architectures/powerpc.md
@@ -1,0 +1,72 @@
+---
+title: PowerPC
+subsection: secondary_architectures
+
+---
+
+# PowerPC
+[PowerPC](https://en.wikipedia.org/wiki/PowerPC) is 32 or 64 bit instruction set architetcure and mainly used in video game consoles and embedded applications. From Fedora 22, support for 32 bit PowerPC machines have been dropped and only 64 bit machines are supported.
+
+## Endianness
+PowerPC supports both little and big endian modes and can even switch from one mode to the other at run-time. In Fedora, Power5 and newer 64 bit machines are supported in big endianness mode and are commonly referred as ppc64. In little endian mode, 64 bit Power8 machines are supported and referred as ppc64le.
+
+## Building your application for PowerPC
+
+To initiate a build for PowerPC, use ppc-koji command:
+
+````
+ppc-koji --scratch build rawhide srpm_pkg1
+````
+
+The above command will start a scratch build of package srpm_pkg1 against Fedora rawhide for ppc64 and ppc64le architectures. Use "ppc-koji \-\-help" in console to see all available options.
+
+To build against other Fedora branches (e.g. F23, F24), specify specific branch name to ppc-koji in argument:
+
+```
+ppc-koji --scratch build F24 srpm_pkg1
+````
+
+If the application is only meant to run on PowerPC, specify ExclusiveArch tag in [RPM spec file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
+
+````
+ExclusiveArch:  ppc64 ppc64le
+````
+
+## Example
+
+In Secondary Architectures section, we saw how to get/create iprutils srpm as an example. Now, you already have srpm (src.rpm) file of iprutils.
+The following example will demonstrate how to build an application for PowerPC architecture from srpm:
+
+````
+# Initiate iprutils package build for PowerPC architecture
+$ ppc-koji build --scratch rawhide iprutils-2.4.11.1-1.fc25.src.rpm
+  Created task: 3298139
+  Task info: http://ppc.koji.fedoraproject.org/koji/taskinfo?taskID=3298139
+  ....
+
+````
+For each build, a Task ID is created in ppc koji. You can see build status and it's log by going to the url provided in Task info.
+
+## Viewing koji builds
+
+Builds specific to ppc64(le) are hosted at [http://ppc.koji.fedoraproject.org/](http://ppc.koji.fedoraproject.org/). UI is very similar to [primary koji](http://koji.fedoraproject.org/).
+
+## Getting access to a powerpc machine
+
+It is possible that to fix/test some issues/features in ppc64(le) quickly, you may require access to a ppc64(le) machine. You can request to:
+
+- Brent Baude - Either email him at <bbaude@redhat.com> or find him on freenode with IRC nick rangerpb
+- [Karsten Hopp](https://fedoraproject.org/wiki/User:Karsten) - Either email him at <karsten@redhat.com> or ask him on frenode with IRC nick kick_ or karsten
+
+## Reaching out for help
+If you face any difficulty reach out to us for help:
+
+- On freenode IRC channel [#fedora-ppc](https://webchat.freenode.net/?channels=#fedora-ppc)
+- Send an email to <ppc@lists.fedoraproject.org> mailing list
+
+## More documentation
+
+- More Fedora PowerPC specific details cane be found at [fedoraproject wiki](https://fedoraproject.org/wiki/Architectures/PowerPC)
+
+
+

--- a/deployment/secondary_architectures/s390.md
+++ b/deployment/secondary_architectures/s390.md
@@ -1,7 +1,8 @@
 ---
-title: s390(x) architectures
+title: s390(x)
 subsection: secondary_architectures
 
+order: 3
 ---
 
 # s390(x)
@@ -13,9 +14,9 @@ s390 is 31-bit-address/32-bit-data and s390x is 64 bit computing architecture. s
 
 To build a package for s390(x) architecture in Fedora, use s390-koji command:
 
-````
+```
 $ s390-koji --scratch build rawhide srpm_pkg1
-````
+```
 
 The above command will start a scratch build of package srpm_pkg1 against Fedora rawhide for s390 and s390x architectures. Use "s390-koji \-\-help" in console to see all available options.
 
@@ -23,37 +24,33 @@ To build against other Fedora branches (e.g. F23, F24), specify specific branch 
 
 ```
 s390-koji --scratch build F24 srpm_pkg1
-````
+```
 
 To package application exclusively for s390(x) archiecture, use ExclusiveArch tag in [RPM spec file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file)
 
-````
+```
 ExclusiveArch:  s390, s390x
-````
+```
 
 ## Example
 
 In Secondary Architectures section, we saw how to get/create iprutils srpm as an example. Now, you already have srpm (src.rpm) file of iprutils.
 The following example will demonstrate how to build an application for s390(x) architecture from srpm:
 
-````
+```
 # Initiate iprutils package build for s390(x) architecture
 $ s390-koji build --scratch rawhide iprutils-2.4.11.1-1.fc25.src.rpm 
   Created task: 2183374
   Task info: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=2183374
   ....
 
-````
+```
 For each build, a Task ID is created in s390 koji. You can view build status and it's log by going to the url provided in Task info.
 
 
 ## Viewing koji builds
 
 Builds specific to s390(x) are hosted at [http://s390.koji.fedoraproject.org/](http://s390.koji.fedoraproject.org/). UI is very similar to [primary koji](http://koji.fedoraproject.org/).
- 
-## Getting access to s390(x) machine
-
-It is possible that to fix/test some issues/features s390(x) quickly, you require access to a s390 machine. Please send an email either directly to [Dan Horák](https://fedoraproject.org/wiki/User:Sharkcz) at <dan@danny.cz> or ask on [s390(x) Mailing List](https://lists.fedoraproject.org/admin/lists/s390x.lists.fedoraproject.org/)
 
 ## Reaching out for help
 
@@ -61,6 +58,7 @@ If you face any difficulty reach out to us for help:
 
 - On freenode by joining channel [#fedora-s390x](https://webchat.freenode.net/?channels=#fedora-s390x)
 - Send an email to <s390x@lists.fedoraproject.org> mailing list
+- Get [s390(x) machine access](https://fedoraproject.org/wiki/Architectures/s390x#Shell_access_for_debugging)
 
 ## More documentation
 

--- a/deployment/secondary_architectures/s390.md
+++ b/deployment/secondary_architectures/s390.md
@@ -1,0 +1,70 @@
+---
+title: s390(x) architectures
+subsection: secondary_architectures
+
+---
+
+# s390(x)
+
+s390 is 31-bit-address/32-bit-data and s390x is 64 bit computing architecture. s390(x) is [big endian](https://en.wikipedia.org/wiki/Endianness) and used in IBM mainframe computers which is also known as [IBM System z](https://en.wikipedia.org/wiki/IBM_System_z).
+
+## Building your application for s390(x) architecture
+
+
+To build a package for s390(x) architecture in Fedora, use s390-koji command:
+
+````
+$ s390-koji --scratch build rawhide srpm_pkg1
+````
+
+The above command will start a scratch build of package srpm_pkg1 against Fedora rawhide for s390 and s390x architectures. Use "s390-koji \-\-help" in console to see all available options.
+
+To build against other Fedora branches (e.g. F23, F24), specify specific branch name to s390-koji in argument:
+
+```
+s390-koji --scratch build F24 srpm_pkg1
+````
+
+To package application exclusively for s390(x) archiecture, use ExclusiveArch tag in [RPM spec file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file)
+
+````
+ExclusiveArch:  s390, s390x
+````
+
+## Example
+
+In Secondary Architectures section, we saw how to get/create iprutils srpm as an example. Now, you already have srpm (src.rpm) file of iprutils.
+The following example will demonstrate how to build an application for s390(x) architecture from srpm:
+
+````
+# Initiate iprutils package build for s390(x) architecture
+$ s390-koji build --scratch rawhide iprutils-2.4.11.1-1.fc25.src.rpm 
+  Created task: 2183374
+  Task info: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=2183374
+  ....
+
+````
+For each build, a Task ID is created in s390 koji. You can view build status and it's log by going to the url provided in Task info.
+
+
+## Viewing koji builds
+
+Builds specific to s390(x) are hosted at [http://s390.koji.fedoraproject.org/](http://s390.koji.fedoraproject.org/). UI is very similar to [primary koji](http://koji.fedoraproject.org/).
+ 
+## Getting access to s390(x) machine
+
+It is possible that to fix/test some issues/features s390(x) quickly, you require access to a s390 machine. Please send an email either directly to [Dan Horák](https://fedoraproject.org/wiki/User:Sharkcz) at <dan@danny.cz> or ask on [s390(x) Mailing List](https://lists.fedoraproject.org/admin/lists/s390x.lists.fedoraproject.org/)
+
+## Reaching out for help
+
+If you face any difficulty reach out to us for help:
+
+- On freenode by joining channel [#fedora-s390x](https://webchat.freenode.net/?channels=#fedora-s390x)
+- Send an email to <s390x@lists.fedoraproject.org> mailing list
+
+## More documentation
+
+More Fedora s390(x) specific details can be found at [Fedora Project  wiki](https://fedoraproject.org/wiki/Architectures/s390x)
+
+
+


### PR DESCRIPTION
This commit adds a new sub-section "Secondary Architectures" under "Deploy and distribute". It will help developers to build application for architectures s390(x), PowerPC using Fedora secondary koji.