### PR TITLE
Add item about PHP SIG

### DIFF
--- a/tech/languages/php/php-sig.md
+++ b/tech/languages/php/php-sig.md
@@ -1,0 +1,11 @@
+---
+title: PHP SIG
+subsection: php
+order: 6
+---
+
+# PHP Special Interest Group
+
+[PHP SIG](https://fedoraproject.org/wiki/SIGs/PHP) is a special interest group within Fedora Project which integrates
+PHP interpreters, libraries and applications into Fedora. If you are interested
+in PHP and Fedora, join us!


### PR DESCRIPTION
Since we have a section for PHP, we should reference the Fedora PHP SIG.