### PR TITLE
updated installation instructions for nunit

### DIFF
--- a/tech/languages/csharp/mono-build-tools-installation.md
+++ b/tech/languages/csharp/mono-build-tools-installation.md
@@ -14,15 +14,7 @@ $ sudo dnf install nant
 
 # NUnit installation
 
-[NUnit](http://nunit.org/) is very useful for test driven development.
-
-To install it on Fedora 21 or Fedora 22, simply type:
-
-```
-$ sudo dnf install mono-nunit
-```
-
-To install it on Fedora 23 or higher, simply type:
+[NUnit](http://nunit.org/) is very useful for test driven development. To install it, simply type:
 
 ```
 $ sudo dnf install nunit

--- a/tech/languages/csharp/mono-build-tools-installation.md
+++ b/tech/languages/csharp/mono-build-tools-installation.md
@@ -17,5 +17,5 @@ $ sudo dnf install nant
 [NUnit](http://nunit.org/) is very useful for test driven development. To install it, simply type:
 
 ```
-$ sudo dnf install nunit-gui
+$ sudo dnf install nunit nunit-gui
 ```

--- a/tech/languages/csharp/mono-build-tools-installation.md
+++ b/tech/languages/csharp/mono-build-tools-installation.md
@@ -17,5 +17,5 @@ $ sudo dnf install nant
 [NUnit](http://nunit.org/) is very useful for test driven development. To install it, simply type:
 
 ```
-$ sudo dnf install nunit
+$ sudo dnf install nunit-gui
 ```


### PR DESCRIPTION
with the recent EOL of Fedora 22, there is no need for explanation anymore how to install nunit on Fedora 22 where it had a different package name.