### PR TITLE
Update to Installing Rails from RubyGems.org

### DIFF
--- a/tech/languages/ruby/ror-installation.md
+++ b/tech/languages/ruby/ror-installation.md
@@ -8,7 +8,7 @@ order: 4
 
 ## Installing Rails from RubyGems.org
 
-To install Ruby on Rails on Fedora as a gem, install Ruby first together with `ruby-devel`, `gcc`, `libxml2-devel` packages, and then install Rails using the `gem` command:
+To install Ruby on Rails on Fedora as a gem, install Ruby first together with `ruby-devel`, `gcc`, `libxml2-devel`, `rpm-build` packages, and then install Rails using the `gem` command:
 
 ```
 $ sudo dnf group install "C Development Tools and Libraries"


### PR DESCRIPTION
Currently in the latest version of Fedora with the latest versions of Ruby it's required to have rpm-build installed as well otherwise the install will fail on both nokogiri and nio4r by installing rpm-build the entire install goes off without a hitch. Adding this option will save developers time when looking to get rails installed and be able to install from RubyGems.org vs only the packaged versions.
