### PR TITLE
Fixed copr API URL

### DIFF
--- a/deployment/copr/copr-cli.md
+++ b/deployment/copr/copr-cli.md
@@ -15,7 +15,7 @@ Install the copr-cli package:
 $ sudo dnf install copr-cli
 ```
 
-Log into the Copr web interface and get your API token at the [Copr API Page](https://copr.fedoraproject.org/api/)
+Log into the Copr web interface and get your API token at the [Copr API Page](https://copr.fedorainfracloud.org/api/)
 
 3. Save the token to your system:
 


### PR DESCRIPTION
The old url was not the correct one, if one would try to login to get his API key, he would be redirected to the homepage of the new site. In fact I have the impression that the entire URL should be using a HTTP redirect to the new domain.