### PR TITLE
Update "Installing Rails from RubyGems.org" for Rails 5.0.x

### DIFF
--- a/tech/languages/ruby/ror-installation.md
+++ b/tech/languages/ruby/ror-installation.md
@@ -8,11 +8,11 @@ order: 4
 
 ## Installing Rails from RubyGems.org
 
-To install Ruby on Rails on Fedora as a gem, install Ruby first together with `ruby-devel`, `gcc`, `libxml2-devel` packages, and then install Rails using the `gem` command:
+To install Ruby on Rails on Fedora as a gem, install Ruby first together with `ruby-devel`, `gcc`, `zlib-devel` packages, and then install Rails using the `gem` command:
 
 ```
 $ sudo dnf group install "C Development Tools and Libraries"
-$ sudo dnf install ruby-devel libxml2-devel
+$ sudo dnf install ruby-devel zlib-devel
 $ gem install rails
 ```
 


### PR DESCRIPTION
Not `libxml2-devel` but `zlib-devel` is required for latest version Rails 5.0.0.1

```
$ gem install rails
...
Fetching: nokogiri-1.6.8.1.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing rails:
	ERROR: Failed to build gem native extension.

    current directory: /builddir/.gem/ruby/gems/nokogiri-1.6.8.1/ext/nokogiri
/usr/bin/ruby -r ./siteconf20161116-16260-y0m2cd.rb extconf.rb
checking if the C compiler accepts ... yes
Building nokogiri using packaged libraries.
Using mini_portile version 2.1.0
checking for gzdopen() in -lz... no
zlib is missing; necessary for building libxml2
...
```
