### PR TITLE
Improved android-studio setup documentation :v:

### DIFF
--- a/start/sw/mobile-app/mobile-devassistant.md
+++ b/start/sw/mobile-app/mobile-devassistant.md
@@ -21,7 +21,10 @@ $ sudo dnf install devassistant
 If you prefer GUI run:
 
 ```bash
-$ sudo dnf install devassistant-guiDevAssistant:
+$ sudo dnf install devassistant-gui
+```
+
+Install DAP plugin [Google Android studio](https://github.com/phracek/dap-google-android-studio) for DevAssistant:
 
 ```bash
 $ da pkg install android-studio

--- a/start/sw/mobile-app/mobile-devassistant.md
+++ b/start/sw/mobile-app/mobile-devassistant.md
@@ -10,7 +10,7 @@ order: 2
 
 You can install it from [Android Studio on developer.android.com](https://developer.android.com/studio/index.html) and follow their instructions.
 
-## From [DevAssistant](https://devassistant.org) command line:
+## From [DevAssistant](https://devassistant.org) command line
 
 First of all install [DevAssistant](https://devassistant.org) project:
 

--- a/start/sw/mobile-app/mobile-devassistant.md
+++ b/start/sw/mobile-app/mobile-devassistant.md
@@ -6,40 +6,42 @@ order: 2
 
 # How to install Google Android Studio on Fedora
 
+## From android website
+
+You can install it from [Android Studio on developer.android.com](https://developer.android.com/studio/index.html) and follow their instructions.
+
+## From [DevAssistant](https://devassistant.org) command line:
 
 First of all install [DevAssistant](https://devassistant.org) project:
 
-```
+```bash
 $ sudo dnf install devassistant
 ```
 
 If you prefer GUI run:
 
-```
-$ sudo dnf install devassistant-gui
-```
+```bash
+$ sudo dnf install devassistant-guiDevAssistant:
 
-Install DAP plugin [Google Android studio](https://github.com/phracek/dap-google-android-studio) for DevAssistant:
-
-```
+```bash
 $ da pkg install android-studio
 ```
 
 If you want to install only packages which are needed by Google Android Studio, run:
 
-```
+```bash
 $ da crt --deps-only android-studio --name <your_project_name>
 ```
 
-For installation Google Android Studio run:
+To install Google Android Studio run:
 
-```
+```bash
 $ da crt android-studio --name <name_of_your_project>
 ```
 
-which downloads the latest versions Google Android Studio and SDKs.
+It will download the latest versions of Google Android Studio and SDKs and will create an empty project, but you can delete the project after installation if you want. Example usage:
 
-```
+```bash
 $ da crt android-studio --name my_test
 INFO: Android studio was not found on system.
 Downloading android studio takes a time. Do you want to continue?
@@ -57,18 +59,55 @@ INFO: /home/$USER/android-studio/bin/studio.sh my_test/build.gradle
 
 ```
 
-For configuring AVD manager run:
-```
+To configure AVD manager run:
+```bash
 $ da crt android-studio --name my_test --avd
 ```
 
-This automatically shows AVD Manager where you can specify your mobile device.
+It will show AVD Manager where you can specify your mobile device.
 
-For downloading SDKs run:
+To download SDKs run:
 
+```bash
+$ da crt android-studio --name my_test --sdk
 ```
-$ da crt android-studio --name my_text --sdk
-```
-This automatically shows SDK Manager where you can specify Android SDK which you would like to download and use it.
+This will show SDK Manager where you can specify Android SDKs to download and install.
 
- 
+## Troubleshooting
+
+When starting Android Studio, you may get the following error:
+
+> 'tools.jar' seems to be not in Studio classpath. Please ensure JAVA_HOME points to JDK rather than JRE.
+
+Make sure you have Oracle JDK Installed, [grab it from here](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+
+Install:
+
+```bash
+$ rpm -ivh jdk-<version>-linux-x64.rpm
+```
+
+Upgrade:
+```bash
+$ rpm -Uvh jdk-<version>-linux-x64.rpm
+```
+
+Enable it using the `alternatives`
+
+```bash
+$ alternatives --config java
+```
+
+Confirm you're using the right java command:
+
+```bash
+$ alternatives --list | grep /usr/java
+java    manual  /usr/java/jdk1.8.0_121/jre/bin/java
+```
+
+```bash
+$ java -version
+java version "1.8.0_121"
+Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
+Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
+```


### PR DESCRIPTION
* `my_test` typo for consistency
* I wasn't sure at first about the `--name <your_project_name>` param,
  but it's mandatory for the command. I didn't need to create a project,
  I only wanted Android Studio for some existing projects, but it can definitely be deleted after.
* I added official instructions as we sometimes fall on devassistant
  before the actual original documentation
* I added troubleshooting part concerning missing JDK Setup