### PR TITLE
venv creation syntax update

### DIFF
--- a/tech/languages/python/django-installation.md
+++ b/tech/languages/python/django-installation.md
@@ -20,7 +20,7 @@ $ cd my_project
 Let's create a virtual environment called `project_venv` which will contain Python and pip which you can use to install Django.
 
 ```bash
-$ pyvenv project_venv
+$ python3 -m venv project_venv
 ```
 
 If you want to work in the virtual environment, you have to activate it.

--- a/tech/languages/python/flask-installation.md
+++ b/tech/languages/python/flask-installation.md
@@ -22,7 +22,7 @@ $ cd my_project
 Let's create a virtual environment called `project_venv` which will contain Python and pip which you can use to install Flask.
 
 ```bash
-$ pyvenv project_venv
+$ python3 -m venv project_venv
 ```
 
 If you want to work in the virtual environment, you have to activate it.

--- a/tech/languages/python/pypi-installation.md
+++ b/tech/languages/python/pypi-installation.md
@@ -23,7 +23,7 @@ The best practise is using pip in the virtual environment. It will keep all modu
 Let's create a virtual environment called `project_venv` which will contain the main Python 3 version in Fedora and pip. If you need to use another version of Python or different interpreter such as PyPy, see [Multiple Interpreters section](https://developer.fedoraproject.org/tech/languages/python/multiple-pythons.html).
 
 ```bash
-$ pyvenv project_venv
+$ python3 -m venv project_venv
 ```
 
 If you want to work in the virtual environment, you have to activate it.

--- a/tech/languages/python/python-installation.md
+++ b/tech/languages/python/python-installation.md
@@ -45,7 +45,7 @@ When you work at some project it is good to keep it inside a virtual environment
 Let's create a virtual environment called `project_venv` which will contain Python and pip which you can use to install project's dependencies.
 
 ```bash
-$ pyvenv project_venv
+$ python3 -m venv project_venv
 ```
 
 If you want to work in the virtual environment, you have to activate it.


### PR DESCRIPTION
As of Python 3.6, pyvenv is deprecated in favor of python3 -m venv (see https://docs.python.org/3/library/venv.html#module-venv).