### PR TITLE
Replace fedorahosted.org links with updated URLs

### DIFF
--- a/deployment/copr/about.md
+++ b/deployment/copr/about.md
@@ -14,8 +14,8 @@ description: >
 
 Before you start, you need to have a source RPM (SRPM). If you do not know how to create a SRPM, then please check [RPM Packaging](../rpm/about.html) section of this documentation.
 
-There is nice a [Screenshot Tutorial](https://fedorahosted.org/copr/wiki/ScreenshotsTutorial), which describes every step.
+There is nice a [Screenshot Tutorial](https://docs.pagure.org/copr.copr/screenshots_tutorial.html#screenshots-tutorial), which describes every step.
 
 If you prefer using the command line, there is [documentation of copr-cli](copr-cli.html).
 
-Note: you can only use Copr for FOSS projects. More details can be found in the [What I can build in Copr](https://fedorahosted.org/copr/wiki/UserDocs#WhatIcanbuildinCopr) section of [Copr FAQ](https://fedorahosted.org/copr/wiki/UserDocs#FAQ).
+Note: you can only use Copr for FOSS projects. More details can be found in the [What I can build in Copr](https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr) section of [Copr FAQ](https://docs.pagure.org/copr.copr/user_documentation.html#faq).


### PR DESCRIPTION
fedorahosted.org is gone, and the COPR documentation now lives on pagure.io. I chased down equivalent URLs for all of the documentation links that had gone rotten.