### PR TITLE
Remove nose from Scientific Python

### DIFF
--- a/tech/languages/python/scipy.md
+++ b/tech/languages/python/scipy.md
@@ -24,7 +24,6 @@ available in Fedora. Well known and widely used is
   for data series manipulation
 * [SymPy](http://www.sympy.org/en/index.html), a Python library for computer algebra
   support (i.e. symbolical computation)
-* [nose](http://nose.readthedocs.io/en/latest/), a testing framework for Python
 * [Jupyter Notebook](https://jupyter.org/), a web app that allows you to create
   and share live code, equations, visualizations and explanatory text
 


### PR DESCRIPTION
* nose has nothing to do with science
 * nose is dead, it says the following on the website:

> Nose has been in maintenance mode for the past several years
> and will likely cease without a new person/team to take over
> maintainership. New projects should consider using Nose2,
> py.test, or just plain unittest/unittest2.