### PR TITLE
Correct path for Go hello example

### DIFF
--- a/tech/languages/go/go-programs.md
+++ b/tech/languages/go/go-programs.md
@@ -28,7 +28,7 @@ func main() {
 }
 ```
 
-Save your changes and, still on the same directory (`$HOME/go/hello`), run:
+Save your changes and, still on the same directory (`$HOME/go/src/hello`), run:
 
 ```console
 $ go run hello.go


### PR DESCRIPTION
The correct path is `$HOME/go/src/hello`, not `$HOME/go/hello`.