### PR TITLE
Fix wrong package name

### DIFF
--- a/tech/languages/haskell/leksah.md
+++ b/tech/languages/haskell/leksah.md
@@ -12,7 +12,7 @@ packages with automatic build of dependencies. It enables standard IDE features 
 To install Leksah run command:
 
 ```
-$ sudo dnf install ghc cabal
+$ sudo dnf install ghc cabal-install
 ```
 
 or install Haskell Platform by command:


### PR DESCRIPTION
`cabal` should be `cabal-install`