### PR TITLE
Change docker registries conf location

### DIFF
--- a/tools/docker/docker-configuration.md
+++ b/tools/docker/docker-configuration.md
@@ -16,4 +16,4 @@ Other area you might tweak is [Network configuration](https://docs.docker.com/en
 
 If you want to change setting of storage that docker engine uses, check [docker-storage-setup](http://www.projectatomic.io/docs/docker-storage-recommendation) script.
 
-If you want to use your own registry, check [Docker Registry](http://docs.docker.com/registry). In that case you'll probably want to add `--add-registry` and/or `--insecure-registry` into `/etc/sysconfig/docker`.
+If you want to use your own registry, check [Docker Registry](http://docs.docker.com/registry). In that case you'll probably want to add `--add-registry` and/or `--insecure-registry` into `/etc/containers/registries.conf`.


### PR DESCRIPTION
Hi

In _/etc/sysconfig/docker_ (which is the old conf location)
on line 9 there is written:
_Do not add registries in this file anymore. Use /etc/containers/registries.conf_