### PR TITLE
Update `Multiple Pythons` page

### DIFF
--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -11,6 +11,7 @@ on multiple Python interpreters. On Fedora, that's easy: all you have to do is
 use `dnf` to install what you need. Currently Fedora has the following Pythons
 ready for you in the repositories:
 
+ * CPython 3.7 (development version)
  * CPython 3.6
  * CPython 3.5
  * CPython 3.4
@@ -26,10 +27,10 @@ Quite a nest, isn't it?
 You can install them like this:
 
 ```bash
-sudo dnf install python33  # to get CPython 3.3
 sudo dnf install python34  # to get CPython 3.4
 sudo dnf install python35  # to get CPython 3.5
 sudo dnf install python36  # to get CPython 3.6
+sudo dnf install python37  # to get CPython 3.7
 sudo dnf install python26  # to get CPython 2.6
 sudo dnf install pypy pypy3 jython python35  # to get more at once
 ```
@@ -49,19 +50,18 @@ Note that most of the CPython versions, other than those provided by the
 `python2` and `python3` packages, are only provided for developer's convenience
 so you can run your test suites. Critical security bugs might not be always
 fixed and those interprets are not intended for production.
+Especially the development version might be quite unstable.
 
 ## Getting it and running it all with tox
 
 [Tox](https://tox.readthedocs.io/) is tool that helps you test your Python code
 on multiple Pythons. If you install it on Fedora via the dnf package manager,
-you'll automatically get all the CPythons and PyPys:
+you'll automatically get all the CPythons (except the development version)
+and PyPys:
 
 ```bash
 sudo dnf install tox
 ```
-
-Note: This will only install the Python interpreters on Fedora 25 or newer,
-on older Fedoras, you need to install the packages specifically.
 
 If you are not yet familiar with tox, don't worry. This short example will show
 you how to start.
@@ -185,8 +185,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 ```
 
 If you don't wish to use Python 2 at all, you might install `python3-virtualenv`
-in the first step and than use `virtualenv-3.X` command instead (where X
-changes depending on your Fedora version).
+in the first step and than use `virtualenv-3` command instead  of `virtualenv`.
 
 To learn more about virtualenvs, visit
 [The Hitchhiker's Guide to Python](http://docs.python-guide.org/en/latest/dev/virtualenvs/).

--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -26,17 +26,17 @@ ready for you in the repositories:
 Quite a nest, isn't it?
 You can install them like this:
 
-```bash
-sudo dnf install python37  # to get CPython 3.7
-sudo dnf install python34  # to get CPython 3.4
-sudo dnf install python26  # to get CPython 2.6
-sudo dnf install pypy pypy3 jython python35  # to get more at once
+```console
+$ sudo dnf install python37  # to get CPython 3.7
+$ sudo dnf install python34  # to get CPython 3.4
+$ sudo dnf install python26  # to get CPython 2.6
+$ sudo dnf install pypy pypy3 jython python35  # to get more at once
 ```
 
 After that, you can run an interactive console or your script with, let's say,
 CPython 3.4:
 
-```
+```console
 $ python3.4
 Python 3.4.3 (default, Jul 11 2016, 11:30:44) 
 [GCC 5.3.1 20160406 (Red Hat 5.3.1-6)] on linux
@@ -56,8 +56,8 @@ on multiple Pythons. If you install it on Fedora via the dnf package manager,
 you'll automatically get all the CPythons (except the development version)
 and PyPys:
 
-```bash
-sudo dnf install tox
+```console
+$ sudo dnf install tox
 ```
 
 If you are not yet familiar with tox, don't worry. This short example will show
@@ -92,7 +92,7 @@ similar.
 
 With `tox.ini`, just run tox in the same directory:
 
-```
+``` console
 $ tox
 [...]
 ERROR:   py27: commands failed
@@ -112,7 +112,7 @@ from __future__ import print_function
 print('Fedora is the best OS for Python developers', end='\n\n')
 ```
 
-```
+```console
 $ tox
 [...]
   py27: commands succeeded
@@ -143,7 +143,7 @@ named `env` and install some package into it.
 Recent versions of Python include the `venv` module, which can create virtual
 environments.
 
-```
+```console
 $ python3.5 -m venv env  # create the virtualenv
 $ . env/bin/activate  # activate it
 (env)$ python -m pip install requests  # install a package with pip
@@ -162,7 +162,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 For other Python versions, a tool called `virtualenv` can create virtual
 environments:
 
-```
+```console
 $ dnf install python-virtualenv  # install the necessary tool
 $ virtualenv --python /usr/bin/python2.7 env  # create the virtualenv
 Running virtualenv with interpreter /usr/bin/python2.7
@@ -194,7 +194,7 @@ It does have a rudimentary pip replacement called
 [upip](https://pypi.python.org/pypi/micropython-upip/), which you can use to
 install packages that support MicroPython. Run it to find out more:
 
-```
-micropython -m upip
+```console
+$ micropython -m upip
 ```
 

--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -27,10 +27,8 @@ Quite a nest, isn't it?
 You can install them like this:
 
 ```bash
-sudo dnf install python34  # to get CPython 3.4
-sudo dnf install python35  # to get CPython 3.5
-sudo dnf install python36  # to get CPython 3.6
 sudo dnf install python37  # to get CPython 3.7
+sudo dnf install python34  # to get CPython 3.4
 sudo dnf install python26  # to get CPython 2.6
 sudo dnf install pypy pypy3 jython python35  # to get more at once
 ```

--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -46,11 +46,10 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> 
 ```
 
-Note that most of the CPython versions, other than those provided by the
-`python2` and `python3` packages, are only provided for developer's convenience
-so you can run your test suites. Critical security bugs might not be always
-fixed and those interprets are not intended for production.
-Especially the development version might be quite unstable.
+**Warning:** For production purposes you should use `python3` or `python2`
+packages only. Other CPython versions might be **unstable** or even **dangerous**
+(either because they are extremely old or quite the contrary alpha/beta quality)
+and are intended solely for development.
 
 ## Getting it and running it all with tox
 


### PR DESCRIPTION
 * Python 3.7 is coming to Fedora 26+
 * Fedora < 25 is not supported
 * python3-virtualenv now has the virtualenv-3 command

Please review. Do not merge before both of the following happens:

 * [x] Fedora 25 is EOL
 * [x] python37 is [pushed to stable in Fedora 26](https://bodhi.fedoraproject.org/updates/FEDORA-2017-3bc4b69c2e) and [Fedora 27](https://bodhi.fedoraproject.org/updates/FEDORA-2017-d3f5db86f9).