### PR TITLE
Update rebase-helper docs

### DIFF
--- a/deployment/maintain/rebase-helper-integration.md
+++ b/deployment/maintain/rebase-helper-integration.md
@@ -1,13 +1,10 @@
 ---
 title: Rebase helper integration
 subsection: maintain
-section: deployment
 order: 3
-description: >
-  Integrating rebase-helper with an upstream monitoring service
 ---
 
-# {{page.description}}
+# Integrating rebase-helper with an upstream monitoring service
 
 This chapter demonstrates how to include rebase-helper in your upstream monitoring service. 
 If you would like to integrate rebase-helper into your upstream monitoring services, this chapter is for you.

--- a/deployment/maintain/rebase-helper-integration.md
+++ b/deployment/maintain/rebase-helper-integration.md
@@ -27,7 +27,7 @@ rh.run()
 ### BASH
 
 ```sh
-$ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
+rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
 ```
 
 ## Download logs and RPMs and compare with tools like ``abipkgdiff``
@@ -43,6 +43,6 @@ rh.get_rebasehelper_data() # Get all information about the results
 ### BASH
 
 ```sh
-$ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
+rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
 ```
 

--- a/deployment/maintain/rebase-helper-integration.md
+++ b/deployment/maintain/rebase-helper-integration.md
@@ -1,0 +1,51 @@
+---
+title: Rebase helper integration
+subsection: maintain
+section: deployment
+order: 3
+description: >
+  Integrating rebase-helper with an upstream monitoring service
+---
+
+# {{page.description}}
+
+This chapter demonstrates how to include rebase-helper in your upstream monitoring service. 
+If you would like to integrate rebase-helper into your upstream monitoring services, this chapter is for you.
+Rebase-helper provides an API which you can use either directly from Python, or directly from the command line.
+
+## Patch new upstream version and start scratch builds
+Example of patching new sources and starting scratch builds with fedpkg.
+ This returns task_ids. The bash equivalents are included for comparison:
+ 
+* **Python API**
+
+   ```python3
+   from rebasehelper.application import Application
+   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', 'upstream_version'])
+   rh = Application(cli)
+   rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
+   rh.run()
+   ```
+
+* **BASH**
+
+   ```sh
+   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
+   ```
+
+## Download logs and RPMs and compare with tools like ``abipkgdiff``
+
+* **Python API**
+
+   ```python3
+   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', '--build-tasks', 'old_id,new_id'])
+   rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
+   rh.get_rebasehelper_data() # Get all information about the results
+   ```
+
+* **BASH**
+
+   ```sh
+   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
+   ```
+

--- a/deployment/maintain/rebase-helper-integration.md
+++ b/deployment/maintain/rebase-helper-integration.md
@@ -15,37 +15,37 @@ Rebase-helper provides an API which you can use either directly from Python, or 
 
 ## Patch new upstream version and start scratch builds
 Example of patching new sources and starting scratch builds with fedpkg.
- This returns task_ids. The bash equivalents are included for comparison:
+This returns task_ids. The bash equivalents are included for comparison:
  
-* **Python API**
+### Python API
 
-   ```python3
-   from rebasehelper.application import Application
-   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', 'upstream_version'])
-   rh = Application(cli)
-   rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
-   rh.run()
-   ```
+```python3
+from rebasehelper.application import Application
+cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', 'upstream_version'])
+rh = Application(cli)
+rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
+rh.run()
+```
 
-* **BASH**
+### BASH
 
-   ```sh
-   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
-   ```
+```sh
+$ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
+```
 
 ## Download logs and RPMs and compare with tools like ``abipkgdiff``
 
-* **Python API**
+### Python API
 
-   ```python3
-   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', '--build-tasks', 'old_id,new_id'])
-   rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
-   rh.get_rebasehelper_data() # Get all information about the results
-   ```
+```python3
+cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', '--build-tasks', 'old_id,new_id'])
+rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
+rh.get_rebasehelper_data() # Get all information about the results
+```
 
-* **BASH**
+### BASH
 
-   ```sh
-   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
-   ```
+```sh
+$ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
+```
 

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -1,13 +1,10 @@
 ---
 title: Rebase helper
 subsection: maintain
-section: deployment
 order: 2
-description: >
-  Helps automate the process of updating a package to the latest upstream version
 ---
 
-# {{page.title}}
+# Rebase-helper
 Rebase-helper is a tool which helps package maintainers with updating package to the latest upstream version.
 It automates a lot of manual tasks the package maintainer usually does, when a new upstream version of a package is released.
 

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -1,10 +1,13 @@
 ---
 title: Rebase helper
 subsection: maintain
+section: deployment
 order: 2
+description: >
+  Helps automate the process of updating a package to the latest upstream version
 ---
 
-# Rebase-helper
+# {{page.title}}
 Rebase-helper is a tool which helps package maintainers with updating package to the latest upstream version.
 It automates a lot of manual tasks the package maintainer usually does, when a new upstream version of a package is released.
 
@@ -45,44 +48,3 @@ If you do not want to be bothered, add the ``--non-interactive`` option to rebas
 
 After rebase-helper finishes, check the output.
 
-## Integrating rebase-helper with an upstream monitoring service
-
-This chapter demonstrates how to include rebase-helper in your upstream monitoring service. 
-If you would like to integrate rebase-helper into your upstream monitoring services, this chapter is for you.
-Rebase-helper provides an API which you can use either directly from Python, or directly from the command line.
-
-### Patch new upstream version and start scratch builds
-Example of patching new sources and starting scratch builds with fedpkg.
- This returns task_ids. The bash equivalents are included for comparison:
- 
-* **Python API**
-
-   ```python3
-   from rebasehelper.application import Application
-   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', 'upstream_version'])
-   rh = Application(cli)
-   rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
-   rh.run()
-   ```
-
-* **BASH**
-
-   ```sh
-   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
-   ```
-
-### Download logs and RPMs and compare with tools like ``abipkgdiff``
-
-* **Python API**
-
-   ```python3
-   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', '--build-tasks', 'old_id,new_id'])
-   rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
-   rh.get_rebasehelper_data() # Get all information about the results
-   ```
-
-* **BASH**
-
-   ```sh
-   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
-   ```

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -8,10 +8,10 @@ order: 2
 Rebase-helper is a tool which helps package maintainers with updating package to the latest upstream version.
 It automates a lot of manual tasks the package maintainer usually does, when a new upstream version of a package is released.
 
-## How to install rebase-helper
+## Installing rebase-helper
 Begin installation on Fedora using the ``dnf`` command:
 
-```
+```sh
 sudo dnf install -y rebase-helper
 ```
 
@@ -20,29 +20,32 @@ These programs are installed automatically as dependencies of rebase-helper.
 
 Note: rebase-helper is also available as EPEL-7 package. Feel free to use it on CentOS and RHEL systems.
 
-## How does the rebase-helper work?
+## How does rebase-helper work?
 Rebase-helper workflow can be summarized in following steps:
 
 - Downloads an archive with new sources.
 - Rebases downstream patches on top of the latest upstream version using git rebase command.
-- If patching was successful, it builds two sets of RPMs. One using the ``old`` sources and a second one using the ``new`` sources. Available build tools are ``mock``, ``rpmbuild``, ``fedpkg``.
-  - If ``new`` RPMs build fails, downloads logs like build.log and root.log
+- If patching was successful, it builds two sets of RPMs. One using the **``old``** sources and a second one using the **``new``** sources. Available build tools are ``mock``, ``rpmbuild``, ``fedpkg``.
+  - If **``new``** RPMs build fails, downloads logs like `build.log` and `root.log`
   - If the build is successful, downloads all available RPM packages.
-- If all builds succeed, rebase-helper runs several checkers, like ``pkgdiff``, ``rpmdiff``, ``abipkgdiff``. Rebase-helper compares old and new packages and reports results.
+- If all builds succeed, rebase-helper runs several checkers, like ``pkgdiff``, ``rpmdiff``, ``abipkgdiff``. Rebase-helper compares **old** and **new** packages and reports results.
 
 ## How to rebase your packages?
-Let's say, we want to rebase a package foobar from ``foobar-1.2.0`` to ``foobar-1.2.1``.
+Let's say we want to rebase a package foobar from ``foobar-1.2.0`` to ``foobar-1.2.1`` using rebase-helper:
 
-To update to the latest upstream version execute command:
+```sh
+# Change to the location of foobar.spec and other package components (cloned dist-git dir), e.g.
+cd $HOME/rpmbuild/REPOS/foobar
 
-```
+# Update to the selected upstream version
 rebase-helper 1.2.1
 ```
 
-If you do not want to be bothered, use option ``--non-interactive``
+If you do not want to be bothered, add the ``--non-interactive`` option to rebase-helper's command line 
+
 After rebase-helper finishes, check the output.
 
-## Integration rebase-helper with an upstream monitoring service
+## Integrating rebase-helper with an upstream monitoring service
 
 This chapter demonstrates how to include rebase-helper in your upstream monitoring service. 
 If you would like to integrate rebase-helper into your upstream monitoring services, this chapter is for you.
@@ -52,34 +55,34 @@ Rebase-helper provides an API which you can use either directly from Python, or 
 Example of patching new sources and starting scratch builds with fedpkg.
  This returns task_ids. The bash equivalents are included for comparison:
  
-* ``Python API``
+* **Python API**
 
-```
-from rebasehelper.application import Application
-cli = CLI([‘--non-interactive, ‘--builds-nowait’, ‘-buildtool’, ‘fedpkg’, upstream_version])
-rh = Application(cli)
-rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
-rh.run()
-```
+   ```python3
+   from rebasehelper.application import Application
+   cli = CLI(['--non-interactive', '--builds-nowait', '-buildtool', 'fedpkg', upstream_version])
+   rh = Application(cli)
+   rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
+   rh.run()
+   ```
 
-* ``BASH``
+* **BASH**
 
-```
-rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
-```
+   ```sh
+   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg <upstream_version>
+   ```
 
-### Download logs and RPMs and compare with tools like abipkgdiff
+### Download logs and RPMs and compare with tools like ``abipkgdiff``
 
-* ``Python API``
+* **Python API**
 
-```
-cli = CLI([‘--non-interactive, ‘--builds-nowait’, ‘--fedpkg-build-tasks old_id,new-id])
-rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
-rh.get_rebasehelper_data() # Get all information about the results
-```
+   ```python3
+   cli = CLI(['--non-interactive', '--builds-nowait', '--fedpkg-build-tasks' old_id,new-id])
+   rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
+   rh.get_rebasehelper_data() # Get all information about the results
+   ```
 
-* ``BASH``
+* **BASH**
 
-```
-rebase-helper --non-interactive --builds-nowait --fedpkg-build-tasks old_id,new-id
-```
+   ```sh
+   rebase-helper --non-interactive --builds-nowait --fedpkg-build-tasks old_id,new-id
+   ```

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -12,7 +12,7 @@ It automates a lot of manual tasks the package maintainer usually does, when a n
 Begin installation on Fedora using the ``dnf`` command:
 
 ```sh
-sudo dnf install -y rebase-helper
+sudo dnf install rebase-helper
 ```
 
 It requires several other programs like ``abipkgdiff``, ``rpmdiff``, ``mock``, ``fedpkg``, ``meld``, etc.

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -8,7 +8,7 @@ order: 2
 Rebase-helper is a tool which helps package maintainers with updating package to the latest upstream version.
 It automates a lot of manual tasks the package maintainer usually does, when a new upstream version of a package is released.
 
-## Installing rebase-helper
+## Install rebase-helper
 Begin installation on Fedora using the ``dnf`` command:
 
 ```sh
@@ -25,8 +25,8 @@ Rebase-helper workflow can be summarized in following steps:
 
 - Downloads an archive with new sources.
 - Rebases downstream patches on top of the latest upstream version using git rebase command.
-- If patching was successful, it builds two sets of RPMs. One using the **``old``** sources and a second one using the **``new``** sources. Available build tools are ``mock``, ``rpmbuild``, ``fedpkg``.
-  - If **``new``** RPMs build fails, downloads logs like `build.log` and `root.log`
+- If patching was successful, it builds two sets of RPMs. One using the **old** sources and a second one using the **new** sources. Available build tools are ``mock``, ``rpmbuild``, ``fedpkg``.
+  - If **new** RPMs build fails, downloads logs like `build.log` and `root.log`
   - If the build is successful, downloads all available RPM packages.
 - If all builds succeed, rebase-helper runs several checkers, like ``pkgdiff``, ``rpmdiff``, ``abipkgdiff``. Rebase-helper compares **old** and **new** packages and reports results.
 

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -12,7 +12,7 @@ It automates a lot of manual tasks the package maintainer usually does, when a n
 Begin installation on Fedora using the ``dnf`` command:
 
 ```sh
-sudo dnf install rebase-helper
+$ sudo dnf install rebase-helper
 ```
 
 It requires several other programs like ``abipkgdiff``, ``rpmdiff``, ``mock``, ``fedpkg``, ``meld``, etc.
@@ -35,10 +35,10 @@ Let's say we want to rebase a package foobar from ``foobar-1.2.0`` to ``foobar-1
 
 ```sh
 # Change to the location of foobar.spec and other package components (cloned dist-git dir), e.g.
-cd $HOME/rpmbuild/REPOS/foobar
+$ cd $HOME/rpmbuild/REPOS/foobar
 
 # Update to the selected upstream version
-rebase-helper 1.2.1
+$ rebase-helper 1.2.1
 ```
 
 If you do not want to be bothered, add the ``--non-interactive`` option to rebase-helper's command line 
@@ -68,7 +68,7 @@ Example of patching new sources and starting scratch builds with fedpkg.
 * **BASH**
 
    ```sh
-   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
+   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
    ```
 
 ### Download logs and RPMs and compare with tools like ``abipkgdiff``
@@ -84,5 +84,5 @@ Example of patching new sources and starting scratch builds with fedpkg.
 * **BASH**
 
    ```sh
-   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
+   $ rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
    ```

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -84,5 +84,5 @@ Example of patching new sources and starting scratch builds with fedpkg.
 * **BASH**
 
    ```sh
-   rebase-helper --non-interactive --builds-nowait --fedpkg-build-tasks old_id,new_id
+   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new_id
    ```

--- a/deployment/maintain/rebase-helper.md
+++ b/deployment/maintain/rebase-helper.md
@@ -59,7 +59,7 @@ Example of patching new sources and starting scratch builds with fedpkg.
 
    ```python3
    from rebasehelper.application import Application
-   cli = CLI(['--non-interactive', '--builds-nowait', '-buildtool', 'fedpkg', upstream_version])
+   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', 'upstream_version'])
    rh = Application(cli)
    rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
    rh.run()
@@ -68,7 +68,7 @@ Example of patching new sources and starting scratch builds with fedpkg.
 * **BASH**
 
    ```sh
-   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg <upstream_version>
+   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
    ```
 
 ### Download logs and RPMs and compare with tools like ``abipkgdiff``
@@ -76,7 +76,7 @@ Example of patching new sources and starting scratch builds with fedpkg.
 * **Python API**
 
    ```python3
-   cli = CLI(['--non-interactive', '--builds-nowait', '--fedpkg-build-tasks' old_id,new-id])
+   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', '--build-tasks', 'old_id,new_id'])
    rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
    rh.get_rebasehelper_data() # Get all information about the results
    ```
@@ -84,5 +84,5 @@ Example of patching new sources and starting scratch builds with fedpkg.
 * **BASH**
 
    ```sh
-   rebase-helper --non-interactive --builds-nowait --fedpkg-build-tasks old_id,new-id
+   rebase-helper --non-interactive --builds-nowait --fedpkg-build-tasks old_id,new_id
    ```

--- a/deployment/maintain/static-analysis.md
+++ b/deployment/maintain/static-analysis.md
@@ -1,7 +1,6 @@
 ---
 title: Static Analysis
 subsection: maintain
-section: deployment
 order: 4
 ---
 

--- a/deployment/maintain/static-analysis.md
+++ b/deployment/maintain/static-analysis.md
@@ -1,7 +1,8 @@
 ---
 title: Static Analysis
 subsection: maintain
-order: 3
+section: deployment
+order: 4
 ---
 
 # Static Analysis


### PR DESCRIPTION
Did some cleanup, lots of formatting, and some minor copyediting in `rebase-helper.md` in the wiki:
* Indented code blocks that are placed under bullet headings
* Fenced code blocks with ` ```sh ` and ` ```python3 ` to enable (minimal) syntax highlighting
* Fenced more filenames / shell commands / package identifiers with backticks
* Removed backtick fencing from some headings and other non-code-literal words in favor of bolding or other (non-monospaced) decoration.
* Some minor grammatical cleanup (on the section headings, primarily).