### PR TITLE
Update and extend section about Rust

### DIFF
--- a/tech/languages/rust/further-reading.md
+++ b/tech/languages/rust/further-reading.md
@@ -1,0 +1,42 @@
+---
+title: Further reading
+subsection: rust
+order: 4
+---
+
+# Learning resources
+
+There is an official book describing the Rust programming language in detail.
+https://doc.rust-lang.org/book/2018-edition/index.html
+
+More examples of the concepts discussed in the book are available in this collection:
+https://doc.rust-lang.org/rust-by-example/
+
+When you finish with the language itself, there is an ongoing effort to create a set of examples of using core libraries for concurrency, data serialization, network programming, etc.
+https://rust-lang-nursery.github.io/rust-cookbook/intro.html
+
+Finally, you can find community pages with a list of resources such as this one:
+https://github.com/ctjhoa/rust-learning
+
+
+# API documentation
+
+Standard library documentation:
+https://doc.rust-lang.org/std/
+
+Documentation for crates available at `crates.io`:
+https://docs.rs/
+
+# IDE recommendations
+
+There are plugins for popular editor such as Vim, Atom or Gnome Software which are based on the Rust Language Server (RLS) implementation. Alternatively, IntelliJ IDEA provides their own, custom plugin. Unfortunatelly, the debugging support is available only in paid CLion IDE.
+https://areweideyet.com/
+
+# Other useful links
+
+If you want to start with some web applications, a list of useful frameworks is available here:
+http://www.arewewebyet.org/
+
+If you are brave enough and you want to try the nightly compiler edition (or you just want to try the awesome [Rocket framework](https://rocket.rs/)), it is recommended to use rustup:
+https://rustup.rs/
+

--- a/tech/languages/rust/rust-cargo.md
+++ b/tech/languages/rust/rust-cargo.md
@@ -6,14 +6,9 @@ order: 2
 
 # Installing Cargo
 Cargo is Rust's package manager. You can use it to download your project's dependencies
-and to compile your project. To install Cargo, type:
+and to compile your project. You can start a new project using Cargo by typing:
 ```
-$ sudo dnf install cargo
-```
-
-You can start a new project using Cargo by typing:
-```
-$ cargo new my_project --bin
+$ cargo new my_project
 ```
 This will create a new directory with manifest (`Cargo.toml`), a source code directory
 (`src`) and a "Hello, World!" program in `src/main.rs`.

--- a/tech/languages/rust/rust-installation.md
+++ b/tech/languages/rust/rust-installation.md
@@ -3,20 +3,16 @@ title: Rust
 subsection: rust
 section: tech-languages
 order: 1
-version: 1.10.0
+version: 1.28
 description: Systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.
 ---
 
 # Rust installation
 
-In order to install the Rust compiler, type:
+In order to get started with Rust programming, type:
 ```
-$ sudo dnf install rust
+$ sudo dnf install rust cargo
 ```
-This will install the compiler (`rustc`), standard library, gdb support and a documentation generator (`rustdoc`).
+This will install the compiler (`rustc`), standard library, gdb support, documentation generator (`rustdoc`) and the package manager (`cargo`).
 
-To compile the Rust source code, type:
-```
-$ rustc test.rs
-```
-This will produce an executable file named `test`.
+Continue to the next section where project cration is discussed.

--- a/tech/languages/rust/rust-sig.md
+++ b/tech/languages/rust/rust-sig.md
@@ -1,0 +1,10 @@
+---
+title: Rust SIG
+subsection: rust
+order: 5
+---
+
+# Rust SIG
+
+Rust Special Interest Group takes care of anything related to Rust in Fedora distribution. You can find more information at the official web pages:
+https://docs.pagure.org/fedora-rust.sig/index.html


### PR DESCRIPTION
Changes:
 * Main page reflects how to get started rather than how to install the compiler
 * Cargo now defaults to binary projects instead of libraries (`cargo new`)
 * Rust SIG
 * useful links