### PR TITLE
There will no more virtualenv-X

### DIFF
--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -162,7 +162,7 @@ For other Python versions, a tool called `virtualenv` can create virtual
 environments:
 
 ```console
-$ dnf install python-virtualenv  # install the necessary tool
+$ dnf install /usr/bin/virtualenv  # install the necessary tool
 $ virtualenv --python /usr/bin/python2.7 env  # create the virtualenv
 Running virtualenv with interpreter /usr/bin/python2.7
 New python executable in env/bin/python2.7
@@ -179,9 +179,6 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> ...
 (env)$ deactivate  # go back to "normal"
 ```
-
-If you don't wish to use Python 2 at all, you might install `python3-virtualenv`
-in the first step and than use `virtualenv-3` command instead  of `virtualenv`.
 
 To learn more about virtualenvs, visit
 [The Hitchhiker's Guide to Python](http://docs.python-guide.org/en/latest/dev/virtualenvs/).


### PR DESCRIPTION
Updated to support both F27/28 and F29/30

Once 28 is EOL, we can chnage the command to `dnf install virtualenv`

See https://src.fedoraproject.org/rpms/python-virtualenv/pull-request/5