### PR TITLE
Added information about desktop GUI applications

### DIFF
--- a/start/sw/gui-app/about.md
+++ b/start/sw/gui-app/about.md
@@ -4,7 +4,23 @@ label: need-help
 title: Desktop GUI Application
 subsection: gui-app
 section: start-sw
-description: 
+description: Create GUI applications for the Desktop
 ---
 
 # Desktop GUI Application
+
+Desktop applications usually uses a graphical toolkit to create their windows.
+In Linux the two most popular toolkits are Qt and GTK+, each support different
+languages and have different features.
+
+Another option to create a Desktop application is using Electron which create
+an embedded browser.
+
+## Choose a toolkit
+
+GTK+ is the toolkit used by GNOME, XFCE, MATE, Cinnamon, LXDE and SOAS.
+Qt is the toolkit used by KDE.
+
+GTK+ is written in C and have official bindings for C++, JavaScript, Python, 
+Vala and Rust.
+Qt is written in C++ and have official bindings for Python.

--- a/start/sw/gui-app/electron.md
+++ b/start/sw/gui-app/electron.md
@@ -1,0 +1,37 @@
+---
+title: Electron
+subsection: gui-app
+section: start-sw
+description: 
+---
+
+# Create an application using Electron
+
+[Electron][0] is cross platform framework for creating desktop applications using
+web technologies. It is developed by GitHub and released under the MIT license.
+
+## Installing the development packages
+
+Electron uses web technologies so before installing Electron you will need to
+install NodeJS and NPM. You can install them by running:
+
+```
+$ sudo dnf install nodejs
+```
+
+or by following the [Node.js](/tech/languages/nodejs/nodejs.html) tutorial.
+
+After installing NodeJS you can simply install electron using NPM or your preferred
+package manager for NodeJS. You can install it using NPM by running:
+
+```
+$ npm install --save-dev electron@latest
+```
+
+after installing nodejs and electron you can follow the [first application][1]
+tutorial on Electron website.
+
+
+
+[0]: https://electronjs.org/
+[1]: https://electronjs.org/docs/tutorial/first-app

--- a/start/sw/gui-app/gtk.md
+++ b/start/sw/gui-app/gtk.md
@@ -1,0 +1,60 @@
+---
+title: GTK+
+subsection: gui-app
+section: start-sw
+description: 
+---
+
+# Create an application using GTK+
+
+GTK+ is a cross platform graphical toolkit which stands for GIMP toolkit.
+It was started in 1998 as an free and open source alternative to Qt which was
+proprietary at the time. GTK+ is published under the GNU LGPL 2.1 license.
+
+## Installing the development packages
+
+GTK+ is written in C so the minimum required to create a GTK+ application is a
+C compiler and the GTK+ development package:
+
+```
+$ sudo dnf install gcc gtk3-devel
+```
+
+After installing the compiler and development package you can follow the GTK+
+[getting started guide][0] on GNOME website.
+
+## Other languages
+
+GTK+ is written in C but it also have official support for C++, JavaScript, 
+Python, Vala and Rust.
+
+### Vala
+
+If you want to develop in Vala, you need to install a Vala compiler in addition
+to the general development packages mentioned above. To do it you can run:
+
+```
+$ sudo dnf install vala
+```
+
+After that you can follow [GNOME Vala tutorial][1] to learn how to develop GUI
+applications with Vala.
+
+## Using GNOME Builder
+
+GNOME Builder is an IDE made by GNOME developers to help create GTK+ applications.
+
+To install GNOME Builder using dnf run the command:
+
+```
+$ sudo dnf install gnome-builder
+```
+
+If you want to install GNOME Builder using Flatpak run the command:
+
+```
+$ flatpak install --from https://flathub.org/repo/appstream/org.gnome.Builder.flatpakref
+```
+
+[0]: https://developer.gnome.org/gtk3/stable/gtk-getting-started.html
+[1]: https://wiki.gnome.org/Projects/Vala/Tutorial

--- a/start/sw/gui-app/qt.md
+++ b/start/sw/gui-app/qt.md
@@ -1,0 +1,14 @@
+---
+title: Qt
+subsection: gui-app
+section: start-sw
+description: 
+---
+
+# Create an application using Qt
+
+[Qt][0] is a cross platform application framework which contains a cross platform
+graphical toolkit. Unlike GTK+ which is developed mostly by Linux users, Qt is
+developed by The Qt Company. Because of that Qt have better cross platform support.
+
+[0]: https://www.qt.io/


### PR DESCRIPTION
I mostly added information about GTK+ because that's what I know. I don't know how to install Qt on Fedora so I leave it for someone else to add.

For Qt we would probably suggest QtCreate and KDevelop in the IDEs section but I'm not sure about Electron. I wanted to suggest Atom and Visual Studio Code (the open source version) but both of them are not in Fedora repositories which is a shame, maybe I will try to learn how to package them.