### PR TITLE
Updated position of --scratch

### DIFF
--- a/deployment/secondary_architectures/s390.md
+++ b/deployment/secondary_architectures/s390.md
@@ -15,7 +15,7 @@ s390 is 31-bit-address/32-bit-data and s390x is 64 bit computing architecture. s
 To build a package for s390(x) architecture in Fedora, use s390-koji command:
 
 ```
-$ s390-koji --scratch build rawhide srpm_pkg1
+$ s390-koji build --scratch rawhide srpm_pkg1
 ```
 
 The above command will start a scratch build of package srpm_pkg1 against Fedora rawhide for s390 and s390x architectures. Use "s390-koji \-\-help" in console to see all available options.
@@ -23,7 +23,7 @@ The above command will start a scratch build of package srpm_pkg1 against Fedora
 To build against other Fedora branches (e.g. F23, F24), specify specific branch name to s390-koji in argument:
 
 ```
-s390-koji --scratch build F24 srpm_pkg1
+s390-koji build --scratch F24 srpm_pkg1
 ```
 
 To package application exclusively for s390(x) archiecture, use ExclusiveArch tag in [RPM spec file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file)


### PR DESCRIPTION
Putting `--scratch` before `build` results in the error `koji: error: no such option: --scratch`; putting it _after_ `build` works.