### PR TITLE
Enable nfs3 service in firewall

### DIFF
--- a/tools/vagrant/vagrant-nfs.md
+++ b/tools/vagrant/vagrant-nfs.md
@@ -19,7 +19,8 @@ $ sudo dnf install nfs-utils && sudo systemctl enable nfs-server
 Afterwards enable `nfs`, `rpc-bind` and `mountd` services for `firewalld`:
 
 ```
-$ sudo firewall-cmd --permanent --add-service=nfs \
+$ sudo firewall-cmd --permanent --add-service=nfs3 \
+    && sudo firewall-cmd --permanent --add-service=nfs \
     && sudo firewall-cmd --permanent --add-service=rpc-bind \
     && sudo firewall-cmd --permanent --add-service=mountd \
     && sudo firewall-cmd --reload


### PR DESCRIPTION
`nfs ` service means NFSv4 in firewalld. `nfs3` is for NFSv3. I don't know in which version of Fedora the nfs3 firewalld service has been introduced. But it was there since at least F29.

NFSv3 is used by vagrant as default at this moment (https://www.vagrantup.com/docs/synced-folders/nfs.html):
> nfs_version (string | integer) - The NFS protocol version to use when mounting the folder on the guest. This defaults to 3.