### PR TITLE
Use libvirt firewall zone for nfs in vagrant

### DIFF
--- a/tools/vagrant/vagrant-nfs.md
+++ b/tools/vagrant/vagrant-nfs.md
@@ -19,10 +19,10 @@ $ sudo dnf install nfs-utils && sudo systemctl enable nfs-server
 Afterwards enable `nfs`, `rpc-bind` and `mountd` services for `firewalld`:
 
 ```
-$ sudo firewall-cmd --permanent --add-service=nfs3 \
-    && sudo firewall-cmd --permanent --add-service=nfs \
-    && sudo firewall-cmd --permanent --add-service=rpc-bind \
-    && sudo firewall-cmd --permanent --add-service=mountd \
+$ sudo firewall-cmd --permanent --zone=libvirt --add-service=nfs3 \
+    && sudo firewall-cmd --permanent --zone=libvirt --add-service=nfs \
+    && sudo firewall-cmd --permanent --zone=libvirt --add-service=rpc-bind \
+    && sudo firewall-cmd --permanent --zone=libvirt --add-service=mountd \
     && sudo firewall-cmd --reload
 ```
 


### PR DESCRIPTION
- the libvirt provider interface virbr0 is using the `libvirt` firewall zone
  https://libvirt.org/firewall.html#fw-firewalld-and-virtual-network-driver