### PR TITLE
Updating the link to the official guide for .NET Core.

### DIFF
--- a/tech/languages/dotnet/dotnetcore.md
+++ b/tech/languages/dotnet/dotnetcore.md
@@ -36,4 +36,4 @@ $ sudo dnf install dotnet-sdk-x.y
 
 ## Getting Started
 
-You can create your first console app following instructions in [this official guide](https://www.microsoft.com/net/learn/get-started-with-dotnet-tutorial#create).
+You can create your first console app following instructions in [this official guide](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/create).


### PR DESCRIPTION
The getting started link to the official guide is using an old link that results in a 404. I have updated it to the new location.