### PR TITLE
Update the Python docs

### DIFF
--- a/tech/languages/python/django-installation.md
+++ b/tech/languages/python/django-installation.md
@@ -1,46 +1,51 @@
 ---
 title: Django
 subsection: python
-order: 3
+order: 4
 ---
 
 # Django
 [Django](https://www.djangoproject.com/) is an open source web application framework written in Python, it encourages rapid development and clean, pragmatic design.
 
-## How to install Django in the virtualenv
-It’s recommended to keep your project inside virtual environment. Let's create a new virtual environment for your project.
+## How to install Django in a virtual environment
 
-At first open the _Terminal_ (press `Alt` + `F1`, type _Terminal_ and click on the black squere icon or just press `Enter`). Second, create a new folder `my_project` open it.
+Fedora includes a `python3-django` package that you can install and import.
+However, unless you are developing or packaging an application for Fedora, it is more useful to install Django as a third-party package inside a *virtual environment*.
+This will keep your project separate from your system, giving you more freedom in choosing additional libraries and their versions, and easing collaboration with people who aren't using Fedora yet.
+
+Let's create a new project and a virtual environment.
+Open the _Terminal_ (press `Alt` + `F1`, type _Terminal_ and click `Enter`).
+Then, create a new folder `my_project`, open it, and create a virtual environment called `project_venv`.
 
 ```bash
 $ mkdir my_project
 $ cd my_project
-```
-
-Let's create a virtual environment called `project_venv` which will contain Python and pip which you can use to install Django.
-
-```bash
 $ python3 -m venv project_venv
 ```
 
-If you want to work in the virtual environment, you have to activate it.
+To work in the virtual environment, you have to activate it.
 
 ```bash
 $ source project_venv/bin/activate
 ```
 
-Running the virtual environment, you can install Django.
+In an active the virtual environment (with the name `(project_venv)` included in your command line prompt), you can install Django [from PyPI](https://developer.fedoraproject.org/tech/languages/python/pypi-install.html).
 
 ```bash
-(project_venv) $ pip install django
+(project_venv) $ python -m pip install django
 ```
-That is all, you have sucessfully installed Django in the virtual environment! Now you can start working on your project.
+
+That is all, you have sucessfully installed Django in the virtual environment!
+Now you can start working on your project.
+
 
 ## First project
 
-This is a short tutorial, how to create your first Django project. You can find a detailed tutorial in [Django Documentation](https://docs.djangoproject.com/en/1.10/intro/tutorial01/).
+This is a short tutorial how to create your first Django project. You can find a detailed tutorial in [Django Documentation](https://docs.djangoproject.com/en/1.10/intro/tutorial01/).
 
-Now it is a good time to activate your virtual environment (see above). Let's initialize your project files structure. Replace `mysite` with the name of your project.
+If you haven't already, activate your virtual environment (see above).
+Then, to start, initialize your project files structure.
+Replace `mysite` with the name of your project.
 
 ```bash
 (project_venv) $ django-admin startproject mysite
@@ -55,16 +60,17 @@ Enter your new directory which was automatically created.
 And run the server.
 
 ```bash
-(project_venv) $ python3 manage.py runserver
+(project_venv) $ python manage.py runserver
 ```
 
 Now that the server’s running, visit http://127.0.0.1:8000/ with your Web browser. You will see a “Welcome to Django” page, in pleasant, light-blue pastel. It worked!
 
 
-When you finish your work, just deactivate the virtual environment.
+When you finish your work, you can deactivate the virtual environment.
 
 ```bash
 (project_venv) $ deactivate
+$
 ```
 
 ### What next?

--- a/tech/languages/python/flask-installation.md
+++ b/tech/languages/python/flask-installation.md
@@ -1,46 +1,47 @@
 ---
 title: Flask
 subsection: python
-order: 4
+order: 5
 ---
 
 # Flask
 
 [Flask](http://flask.pocoo.org/) is a micro web framework for Python, based on the Werkzeug toolkit and Jinja2 template engine.
 
-## Installation of Flask in the virtualenv
+## Installation of Flask in a virtual environment
 
-It’s recommended to keep your project inside virtual environment. Let's install and create a new virtual environment for your project.
+Fedora includes a `python3-flask` package that you can install and import.
+However, unless you are developing or packaging an application for Fedora, it is more useful to install Flask as a third-party package inside a *virtual environment*.
+This will keep your project separate from your system, giving you more freedom in choosing additional libraries and their versions, and easing collaboration with people who aren't using Fedora yet.
 
-At first open the _Terminal_ (press `Alt` + `F1`, type _Terminal_ and click on the black squere icon or just press `Enter`). Second, create a new folder `my_project` open it.
+Let's create a new project and a virtual environment.
+Open the _Terminal_ (press `Alt` + `F1`, type _Terminal_ and click `Enter`).
+Then, create a new folder `my_project`, open it, and create a virtual environment called `project_venv`.
 
 ```bash
 $ mkdir my_project
 $ cd my_project
-```
-
-Let's create a virtual environment called `project_venv` which will contain Python and pip which you can use to install Flask.
-
-```bash
 $ python3 -m venv project_venv
 ```
 
-If you want to work in the virtual environment, you have to activate it.
+To work in the virtual environment, you have to activate it.
 
 ```bash
 $ source project_venv/bin/activate
 ```
 
-Running the virtual environment, you can install Flask.
+In an active the virtual environment (with the name `(project_venv)` included in your command line prompt), you can install Flask [from PyPI](https://developer.fedoraproject.org/tech/languages/python/pypi-install.html).
 
 ```bash
-(project_venv) $ pip install flask
+(project_venv) $ python -m pip install flask
 ```
-That is all, you have sucessfully installed Flask in the virtual environment! Now you can start working on your project.
+That is all, you have sucessfully installed Flask in the virtual environment!
+Now you can start working on your project.
 
 ## First application
 
 This is an example of how a minimal Flask application can look like.
+Save the code as `hello.py`.
 
 ```python
 from flask import Flask
@@ -49,26 +50,31 @@ app = Flask(__name__)
 @app.route("/")
 def hello_world():
     return "Hello World!"
-
-if __name__ == "__main__":
-    app.run()
 ```
 
 ### Running
 
-Assuming that you have some Flask application called `foo.py`, you can run it in your activated virtual environment (see above) like this.
+To run a Flask app in a development server, set an environment variable to tell Flask where the app is, and then run `flask`:
+
+Assuming that you have some Flask application called `hello.py`, you can run it in your activated virtual environment (see above) like this.
 
 ```bash
-(project_venv) $ python3 foo.py
+(project_venv) $ export FLASK_APP=hello.py
+(project_venv) $ python -m flask
  * Running on http://127.0.0.1:5000/
 ```
 
-You should see that it is running on some address, in this case 127.0.0.1. Default port for Flask applications is 5000. Open it in web browser to see your application.
+You should see that it is running on some address, in this case 127.0.0.1.
+Open the address shown in a web browser to see your application.
 
-When you finish your work, just deactivate the virtual environment.
+And you're off!
+See [Flask's website](https://flask.palletsprojects.com/) for complete documentation and deployment options.
+
+When you finish your work, you can deactivate the virtual environment.
 
 ```bash
 (project_venv) $ deactivate
+$
 ```
 
 ### What next?

--- a/tech/languages/python/micropython.md
+++ b/tech/languages/python/micropython.md
@@ -1,7 +1,7 @@
 ---
 title: MicroPython
 subsection: python
-order: 4
+order: 6
 ---
 
 # MicroPython - Python for microcontrollers
@@ -32,23 +32,25 @@ and then start an interactive MicroPython session.
 
 ```
 $ micropython
-MicroPython v1.7 on 2016-04-20; linux version
+MicroPython v1.12 on 2020-04-15; linux version
 Use Ctrl-D to exit, Ctrl-E for paste mode
 >>>
 ```
 
 Using MicroPython on your computer makes sense only for some basic testing
-purposes, but the main goal is to control embedded devices.
+purposes.
+Its main goal is to control embedded devices.
 
 ## Mu - simple IDE for BBC micro:bit
 
 Micro:bit tries to be as simple to use as possible, so its developers decided
-to make their own IDE named *Mu*. *Mu* is designated for kids to
-learn the basics of programming. Your device is mounted automatically in Fedora,
-so you only need one click to flash your micro:bit with your new app or to
-start REPL.
+to make their own IDE named *Mu*. *Mu* is designed for beginners to
+learn the basics of programming.
+When coding in *Mu*, you only need one click to flash (upload) your app
+to your micro:bit or to start the REPL, an interactive Python session.
+Your device is mounted automatically in Fedora.
 
-*Mu* is a part of Fedora, so its installation command is
+*Mu* is a part of Fedora, so you can install it with:
 
 ```
 $ sudo dnf install mu
@@ -83,12 +85,13 @@ the first parameter for `uflash`.
 $ uflash ./hello_world.py
 ```
 
-## Esptool - CLI for flashing boards with the ESP8266 chip
+## Esptool - CLI for flashing boards with the ESP8266/ESP32 chip
 
-If you want to control your ESP8266 device using MicroPython, write MicroPython firmware into the flash memory of your device.
+If you want to control your ESP8266/ESP32 device using MicroPython, write MicroPython firmware into the flash memory of your device.
 
 You can download MicroPython firmware from [the download section of its web page](http://micropython.org/download/).
 Choose the latest one suitable for your device.
+The download page includes detailed (but not Fedora-specific) information. If you run into problems, use the tutorials it links to.
 
 `esptool` is a handy CLI application that helps you flash your device. To install it, type
 
@@ -124,6 +127,7 @@ $ sudo usermod -a -G dialout <username>
 ```
 
 It is necessary to logout and login for this change to take effect.
+Alternatively, re-login with the command `su - $(whoami)`, but note that this will only affect the your current console session.
 
 Use `esptool` to flash your device. It is suggested to erase the flash
 memory before writing new firmware. To do it, type the following and do not forget to replace `ttyUSB0` with the name of your device.
@@ -139,8 +143,10 @@ Erasing flash (this may take a while)...
 
 And now you can write MicroPython firmware to empty the flash memory. Again, do not forget to replace `ttyUSB0` with the name of your device.
 
+For an ESP8266:
+
 ```
-$ esptool --port /dev/ttyUSB0 --baud 115200 write_flash --flash_size=8m 0 esp8266-20160909-v1.8.4.bin 
+$ esptool --port /dev/ttyUSB0 --baud 115200 write_flash --flash_size=detect 0 esp8266-20200911-v1.13.bin
 esptool.py v1.1
 Connecting...
 Running Cesanta flasher stub...
@@ -150,13 +156,19 @@ Wrote 565248 bytes at 0x0 in 49.0 seconds (92.3 kbit/s)...
 Leaving...
 ```
 
+For an ESP32, the command is slightly different:
+
+```
+$ esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 460800 write_flash -z 0x1000 esp32-idf3-20200902-v1.13.bin
+```
+
 You might need to change the name of your device and the name of the binary file with
-firmware, but other parameters such as a baud-rate (connection speed) should be OK
-in most cases.
+firmware, and some devices require a different `--flash_mode` setting -- see `esptool write_flash --help` for the options.
+Other parameters such as a baud-rate (connection speed) should be OK in most cases.
 
 ## Picocom - minimal terminal emulation program
 
-A lot of microcontrollers (like those with the ESP8266 chip) provide a serial
+A lot of microcontrollers (like those with the ESP8266/ESP32 chip) provide a serial
 console for communication with the outer world. Fedora provides a
 minimalistic and handy tool for connecting to it - `picocom`.
 
@@ -193,13 +205,13 @@ Terminal ready
 >>>
 ```
 
-`-b` parameter sets the baud-rate to 115200 bps which is the connection speed.
+The `-b` parameter sets the baud-rate to 115200 bps, MicroPython's default connection speed on these devices.
 
 The last line of the output (the one with `>>>`) means that MicroPython on your device
 is ready to be used. If you do not see the last line, press *Enter* on your keyboard. If you still do not see the prompt, press RESET on your device.
 
 ```
->>> print('Let the connecting to IoT begins!')
-Let the connecting to IoT begins!
+>>> print('Let the connecting to IoT begin!')
+Let the connecting to IoT begin!
 >>>
 ```

--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -1,14 +1,18 @@
 ---
 title: Multiple Pythons
 subsection: python
-order: 8
+order: 3
 ---
 
 # Multiple Python interpreters
 
 If you are working on a piece of Python software, you probably want to test it
 on multiple Python interpreters. On Fedora, that's easy: all you have to do is
-use `dnf` to install what you need. Currently Fedora has the following Pythons
+use `dnf` to install what you need.
+
+Fedora includes all Python versions which are [supported upstream](https://devguide.python.org/#status-of-python-branches), a few older ones and possibly a pre-release of a newer one.
+
+At the time of this writing, Fedora has the following Pythons
 ready for you in the repositories:
  
  * CPython 3.9
@@ -16,9 +20,7 @@ ready for you in the repositories:
  * CPython 3.7
  * CPython 3.6
  * CPython 3.5
- * CPython 3.4
  * CPython 2.7
- * CPython 2.6\*
  * PyPy
  * PyPy 3
  * Jython\*
@@ -28,21 +30,21 @@ Quite a nest, isn't it?
 You can install them like this:
 
 ```console
-$ sudo dnf install python39  # to get CPython 3.9
-$ sudo dnf install python38  # to get CPython 3.8
-$ sudo dnf install python37  # to get CPython 3.7
-$ sudo dnf install python34  # to get CPython 3.4
-$ sudo dnf install python26  # to get CPython 2.6
-$ sudo dnf install pypy pypy3 jython python35  # to get more at once
+$ sudo dnf install python3.9  # to get CPython 3.9
+$ sudo dnf install python3.8  # to get CPython 3.8
+$ sudo dnf install python3.7  # to get CPython 3.7
+$ sudo dnf install python3.6  # to get CPython 3.7
+$ sudo dnf install python2.7  # to get CPython 2.7
+$ sudo dnf install pypy pypy3 jython python3.5  # to get more at once
 ```
 
 After that, you can run an interactive console or your script with, let's say,
-CPython 3.4:
+CPython 3.6:
 
 ```console
-$ python3.4
-Python 3.4.3 (default, Jul 11 2016, 11:30:44) 
-[GCC 5.3.1 20160406 (Red Hat 5.3.1-6)] on linux
+$ python3.6
+Python 3.6.12 (default, Aug 19 2020, 00:00:00) 
+[GCC 10.2.1 20200723 (Red Hat 10.2.1-1)] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> 
 ```
@@ -83,7 +85,7 @@ directory:
 
 ```
 [tox]
-envlist = py27,py35,py36,pypy,pypy3
+envlist = py27,py37,py38,py39,pypy,pypy3
 skipsdist = True
 [testenv]
 commands=python say.py
@@ -93,18 +95,19 @@ The `envlist` directive defines the list of Pythons to test on.
 Normally, tox assumes you are testing a project with its own `setup.py`. For
 the simplicity of this demo, we are not using it, and we need to tell this to
 tox via the `skipsdist` option.
-Finally the `commands` in `[testenv]` section tells tox what commands to run
-for the test, normally that would be `python setup.py test`, `py.test` or
-similar.
+Finally the `commands` in the `[testenv]` section tells tox what commands to run
+for the test.
+Normally, that would be `python setup.py test`, `py.test` or similar.
 
-With `tox.ini`, just run tox in the same directory:
+With `tox.ini` in place, run `tox` in the same directory:
 
 ``` console
 $ tox
 [...]
 ERROR:   py27: commands failed
-  py35: commands succeeded
-  py36: commands succeeded
+  py37: commands succeeded
+  py38: commands succeeded
+  py39: commands succeeded
 ERROR:   pypy: commands failed
   pypy3: commands succeeded
 ```
@@ -123,8 +126,9 @@ print('Fedora is the best OS for Python developers', end='\n\n')
 $ tox
 [...]
   py27: commands succeeded
-  py35: commands succeeded
-  py36: commands succeeded
+  py37: commands succeeded
+  py38: commands succeeded
+  py39: commands succeeded
   pypy: commands succeeded
   pypy3: commands succeeded
   congratulations :)
@@ -133,36 +137,42 @@ $ tox
 If you want to use tox for your projects, you can learn more at
 [the documentation](https://tox.readthedocs.io/).
 
-## Creating virtualenvs and installing packages
+## Creating virtual environments and installing packages
 
-Fedora only packages Python modules for current versions of `python2`
-and `python3`. For all other interpreters, you will need to install packages
+Fedora only packages Python modules for current versions of `python3`.
+For all other interpreters, you will need to install packages
 from [PyPI](https://pypi.python.org/pypi), the Python Package Index.
 
-The best way is to use Python virtual environments (virtualenvs, or venvs).
+The best way is to use Python virtual environments.
 The invocation to create them differs for different Python versions.
-Packages installed in a virtualenv are only available once the virtualenv
-is activated. Here you can see two demos that create virtualenv in a folder
+Packages installed in a virtual environment are only available once the
+environment is activated.
+Here you can see two demos that create a virtual environment in a folder
 named `env` and install some package into it.
 
 ### Python 3 (including PyPy 3)
 
 Recent versions of Python 3 include the `venv` module, which can create virtual
 environments.
+See the [PyPI & pip section](https://developer.fedoraproject.org/tech/languages/python/pypi-install.html) for details.
 
 ```console
-$ python3.5 -m venv env  # create the virtualenv
-$ . env/bin/activate  # activate it
+$ python3.9 -m venv env  # create the environment
+$ source env/bin/activate  # activate it
 (env)$ python -m pip install requests  # install a package with pip
 ...
-(env)$ python  # run python from that virtualenv
-Python 3.5.2 (default, Aug 16 2016, 21:50:46) 
-[GCC 5.3.1 20160406 (Red Hat 5.3.1-6)] on linux
+(env)$ python  # run python from that environment
+Python 3.9.0 (default, Oct  6 2020, 00:00:00) 
+[GCC 10.2.1 20200723 (Red Hat 10.2.1-1)] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> import requests
 >>> ...
+>>> exit()
 (env)$ deactivate  # go back to "normal"
 ```
+
+The environment is a directory.
+If you no longer need it, deactivate it and delete it with `rm -rv env`.
 
 ### Python 2.7, PyPy 2
 
@@ -170,13 +180,13 @@ For other Python versions, a tool called `virtualenv` can create virtual
 environments:
 
 ```console
-$ dnf install /usr/bin/virtualenv  # install the necessary tool
+$ sudo dnf install /usr/bin/virtualenv  # install the necessary tool
 $ virtualenv --python /usr/bin/python2.7 env  # create the virtualenv
 Running virtualenv with interpreter /usr/bin/python2.7
 New python executable in env/bin/python2.7
 Also creating executable in env/bin/python
 Installing setuptools, pip...done.
-$ . env/bin/activate  # activate it
+$ source env/bin/activate  # activate it
 (env)$ python -m pip install requests  # install a package with pip
 ...
 (env)$ python  # run python from that virtualenv
@@ -185,38 +195,25 @@ Python 2.7.11 (default, Jul  8 2016, 19:45:00)
 Type "help", "copyright", "credits" or "license" for more information.
 >>> import requests
 >>> ...
+>>> exit()
 (env)$ deactivate  # go back to "normal"
 ```
 
-To learn more about virtualenvs, visit
-[The Hitchhiker's Guide to Python](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
 
-### Python 2.6, Jython
 
-The versions of virtualenv and tox packages in Fedora do not support the
-following interpreters:
-* Python 2.6
-* Jython
+### Jython
 
-If you really need to support such old interpreters, you will need to work around some issues or install
-and use older virtualenv/tox from PyPI.
+The versions of virtualenv and tox packages in Fedora do not support Jython,
+an interpreter that interoperates with the Java ecosystem.
 
-A workaround for Python 2.6 is to chnage the `install` and the `list_dependencies` commands with a `tox.ini` configuration like:
+If you need to support it, you will need to install
+and use older virtualenv/tox versions from PyPI.
 
-```
-[testenv:py26]
-install_command = pip install {opts} {packages}
-list_dependencies_command = pip freeze
-basepython = python2.6
-```
-
-A more generic approach is to install an older version of tox that still supports these python versions:
-
-First, create a virtual environment with a newer Python, preferably `python3`:
+First, create and activate a virtual environment with a newer Python, preferably `python3`:
 
 ```console
 $ python3 -m venv py3env
-$ . py3env/bin/activate  # activate it
+$ source py3env/bin/activate  # activate it
 ```
 
 Then, install older packages (virtualenv 15 and tox 2) into it:
@@ -227,32 +224,30 @@ Then, install older packages (virtualenv 15 and tox 2) into it:
 
 Now, whenever the Python 3 virtual environment is activated, you can invoke
 tox 2 using the `tox` command.
-Include `py26` and/or `jython` in the `envlist` section in `tox.ini` to test
-on the old interpreters.
+Include `jython` in the `envlist` section in `tox.ini` to test
+on that interpreters.
 
-You can also use the older virtualenv to create environments for
-Python 2.6 or Jython:
+You can also use the older virtualenv to create environments for Jython:
 
 ```console
-(py3env)$ python -m virtualenv --python /usr/bin/python2.6 py26env
-(py3env)$ python -m virtualenv --python /usr/bin/jython jyenv
+(py3env)$ python -m virtualenv --python /usr/bin/jython jyenv --no-setuptools --no-pip --no-wheel
 ```
 
 To activate these, you don't need the `py3env` activated.
 That is only needed to create them.
 
 ```console
-$ . py26env/bin/activate
-(py26env)$ python --version
-Python 2.6.9
-(py26env)$ deactivate
-```
-
-```console
-$ . jyenv/bin/activate
+$ source jyenv/bin/activate
 (jyenv)$ python --version
 Jython 2.7.1
-(jyenv)$ deactivate
+```
+
+To be able to install packages, run Jython's `ensurepip` command.
+This will install a compatible version of `pip`.
+
+```console
+(jyenv)$ python -m ensurepip
+(jyenv)$ python -m pip install requests
 ```
 
 ### MicroPython

--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -15,13 +15,14 @@ Fedora includes all Python versions which are [supported upstream](https://devgu
 At the time of this writing, Fedora has the following Pythons
 ready for you in the repositories:
  
+ * CPython 3.10
  * CPython 3.9
  * CPython 3.8
  * CPython 3.7
  * CPython 3.6
  * CPython 3.5
  * CPython 2.7
- * PyPy
+ * PyPy 2
  * PyPy 3
  * Jython\*
  * MicroPython\*
@@ -35,7 +36,7 @@ $ sudo dnf install python3.8  # to get CPython 3.8
 $ sudo dnf install python3.7  # to get CPython 3.7
 $ sudo dnf install python3.6  # to get CPython 3.7
 $ sudo dnf install python2.7  # to get CPython 2.7
-$ sudo dnf install pypy pypy3 jython python3.5  # to get more at once
+$ sudo dnf install pypy2 pypy3 jython python3.5  # to get more at once
 ```
 
 After that, you can run an interactive console or your script with, let's say,
@@ -97,7 +98,7 @@ the simplicity of this demo, we are not using it, and we need to tell this to
 tox via the `skipsdist` option.
 Finally the `commands` in the `[testenv]` section tells tox what commands to run
 for the test.
-Normally, that would be `python setup.py test`, `py.test` or similar.
+Normally, that would be `python setup.py test`, `pytest` or similar.
 
 With `tox.ini` in place, run `tox` in the same directory:
 
@@ -139,7 +140,7 @@ If you want to use tox for your projects, you can learn more at
 
 ## Creating virtual environments and installing packages
 
-Fedora only packages Python modules for current versions of `python3`.
+Fedora only packages Python modules for one current version of `python3`.
 For all other interpreters, you will need to install packages
 from [PyPI](https://pypi.python.org/pypi), the Python Package Index.
 
@@ -260,4 +261,3 @@ install packages that support MicroPython. Run it to find out more:
 ```console
 $ micropython -m upip
 ```
-

--- a/tech/languages/python/pygobject.md
+++ b/tech/languages/python/pygobject.md
@@ -1,7 +1,7 @@
 ---
 title: PyGObject
 subsection: python
-order: 6
+order: 8
 ---
 
 # PyGObject (PyGI)
@@ -26,7 +26,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 ```
 
-In the beginning, we have to import the Gtk module to be able to access GTK+’s classes and functions. Since a user’s system can have multiple versions of GTK+ installed at the same, we want to make sure that we when we import Gtk that it referrs to GTK+ 3 and not any other version of the library, which is the purpose of statement gi.require_version('Gtk', '3.0').
+In the beginning, we have to import the Gtk module to be able to access GTK+’s classes and functions. Since a user’s system can have multiple versions of GTK+ installed at the same, we want to make sure that we when we import Gtk that it refers to GTK+ 3 and not any other version of the library, which is the purpose of statement gi.require_version('Gtk', '3.0').
 
 ```
 win = Gtk.Window()
@@ -57,7 +57,7 @@ Gtk.main()
 
 Finally, we start the GTK+ processing loop which we quit when the window is closed.
 
-To run the program, open a terminal, change to the directory of the file, and enter:
+To run the program, save the file as `hello.py`, then open a terminal, change to the directory of the file, and enter:
 
 ```
 $ python hello.py

--- a/tech/languages/python/pypi-installation.md
+++ b/tech/languages/python/pypi-installation.md
@@ -6,11 +6,11 @@ order: 2
 
 # Using pip
 
-If a Python module you need is not packaged for Fedora,
+If a Python package you need is not packaged for Fedora,
 or if you need it in an isolated environment,
 you can use `pip` to install it from the [Python Package Index (PyPI)](https://pypi.python.org/).
 
-Note that software on PyPI is not part of Fedora, and has different standards of quality and security: essentially, anyone can upload code there.
+Note that software on PyPI is not part of Fedora, and has different standards of quality, security and licensing: essentially, anyone can upload code there.
 Only install software you trust, and always double-check `install` commands for typos in package names.
 
 You can either install such modules to a *virtual environment*, or to your home directory with the `--user` user switch. See below for both options.

--- a/tech/languages/python/pypi-installation.md
+++ b/tech/languages/python/pypi-installation.md
@@ -1,26 +1,29 @@
 ---
-title: PyPI
+title: Pip & PyPI
 subsection: python
 order: 2
 ---
 
 # Using pip
 
-If a Python module you need is not packaged for Fedora, you can use pip to install it from [PyPI](https://pypi.python.org/), but you must be a little careful. Installing modules with pip to system directories can lead to unstable system, so make sure you only use pip with the ```--user``` switch, which makes pip install modules to your home directory.
+If a Python module you need is not packaged for Fedora,
+or if you need it in an isolated environment,
+you can use `pip` to install it from the [Python Package Index (PyPI)](https://pypi.python.org/).
 
-Pip gets installed alongside with Python. For Python 3 it is `pip3`, so for example, you want to install `bokeh` (interactive plots in HTML for Python) from PyPI simply type:
+Note that software on PyPI is not part of Fedora, and has different standards of quality and security: essentially, anyone can upload code there.
+Only install software you trust, and always double-check `install` commands for typos in package names.
 
-```
-$ pip3 install --user bokeh
-```
+You can either install such modules to a *virtual environment*, or to your home directory with the `--user` user switch. See below for both options.
 
-And there you go!
+Installing modules with pip to system directories is not recommended, as it can override system libraries and lead to an unstable system.
+
 
 ## Using pip in the virtual environment
 
 The best practise is using pip in the virtual environment. It will keep all modules for one project at one place and it will not break your local system. Another advantage is that you can have more versions of the same module in different virtual environments.
 
-Let's create a virtual environment called `project_venv` which will contain the main Python 3 version in Fedora and pip. If you need to use another version of Python or different interpreter such as PyPy, see [Multiple Interpreters section](https://developer.fedoraproject.org/tech/languages/python/multiple-pythons.html).
+Let's create a virtual environment called `project_venv` with the main Python 3 version in Fedora.
+If you need to use another version of Python or a different interpreter such as PyPy, see the [Multiple Interpreters section](https://developer.fedoraproject.org/tech/languages/python/multiple-pythons.html).
 
 ```bash
 $ python3 -m venv project_venv
@@ -33,9 +36,10 @@ $ source project_venv/bin/activate
 ```
 
 When the virtual environment is activated (you can see it's name in brackets at the beginning of your prompt), you can install modules with pip.
+For example, if your project needs the [`requests`](https://requests.readthedocs.io/en/master/) library, run:
 
 ```bash
-(project_venv) $ pip install module_name
+(project_venv) $ python -m pip install requests
 ```
 
 When you finish your work, just deactivate the virtual environment.
@@ -43,6 +47,25 @@ When you finish your work, just deactivate the virtual environment.
 ```bash
 (project_venv) $ deactivate
 ```
+
+The environment is a directory.
+If you no longer need it, deactivate it and delete it with `rm -rv project_venv`.
+
+
+## User-specific installation
+
+Sometimes, you don't want to use a virtual environment.
+For example, you're installing a tool you will use in multiple projects, but the tool is not available in Fedora repositories.
+In such cases, install with the `--user` option.
+For example, to install a Python implementation of `cowsay` (rather than the original Perl one available in Fedora), run:
+
+```bash
+$ python -m pip install --user cowsay
+```
+
+If you're feeling lucky or impatient, you can use the shorter command `pip install cowsay`, without the `python -m`.
+Usually, this will install using the correct version of Python.
+
 
 ### What next?
 

--- a/tech/languages/python/python-installation.md
+++ b/tech/languages/python/python-installation.md
@@ -3,7 +3,7 @@ title: Python
 subsection: python
 section: tech-languages
 order: 1
-version: 3.5.2
+version: 3.9.0
 description: General-purpose, high-level programming language supporting multiple programming paradigms.
 ---
 
@@ -18,8 +18,8 @@ Python 3 is already pre-installed on Fedora. Let's use it!
 2. To run Python 3 type `python3`. You should see something like this:
 
 ```python
-Python 3.5.2 (default, Sep 14 2016, 11:28:32)
-[GCC 6.2.1 20160901 (Red Hat 6.2.1-1)] on linux
+Python 3.9.0 (default, Oct  6 2020, 00:00:00) 
+[GCC 10.2.1 20201005 (Red Hat 10.2.1-5)] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> 
 ```
@@ -38,9 +38,24 @@ To run a program written in Python, type `python3` followed by the path and name
 $ python3 example.py
 ```
 
-## Using virtualenv
+The command `python` (without the `3`) will also work.
+You can also use a specific version of Python, like `python3.9`, if you have that interpreter installed.
+See the [Multiple Interpreters section](https://developer.fedoraproject.org/tech/languages/python/multiple-pythons.html) for details.
+
+
+## Python packages
+
+Fedora contains many popular packages for Python.
+Usually, they are named with a `python3-` prefix, such as `python3-requests`.
+
+These are useful for scripting and exploring Python and for Fedora-specific applications.
+For software development or reproducible data analysis, it is better to use virtual environments.
+
+
+## Using virtual environments
 
 When you work on a project, it is good to keep it inside a virtual environment. It will keep the dependencies you need in one place and you do not have to worry about different projects which need different versions of the same module.
+It also makes it easy to collaborate with people who don't use Fedora yet.
 
 Let's create a virtual environment called `project_venv` which will contain Python and pip. You can use pip to install a project's dependencies.
 
@@ -57,16 +72,21 @@ $ source project_venv/bin/activate
 When the virtual environment is activated (you can see its name in brackets at the beginning of your prompt), you can install modules via `pip install`.
 
 ```bash
-(project_venv) $ pip install name_of_module
+(project_venv) $ python -m pip install requests
 ```
 
 That is all, you have successfully created your own virtual environment. Now you can run Python (see above) and start working on your project.
 
-When you finish your work, just deactivate the virtual environment.
+When you finish your work, you can deactivate the virtual environment.
 
 ```bash
 (project_venv) $ deactivate
 ```
+
+Note that packages installed system-wide are not available in the virtual environments:
+by default, virtual environments are isolated from the system.
+As an alternative, you can create the environment with `--system-site-packages` -- but note that when you update your Fedora packages, they may get out of sync with modules installed inside the environment.
+
 
 ### What next?
 

--- a/tech/languages/python/python-sig.md
+++ b/tech/languages/python/python-sig.md
@@ -1,7 +1,7 @@
 ---
 title: Python SIG
 subsection: python
-order: 5
+order: 7
 ---
 
 # Python Special Interest Group

--- a/tech/languages/python/scipy.md
+++ b/tech/languages/python/scipy.md
@@ -1,7 +1,7 @@
 ---
 title: Scientific Python Stack
 subsection: python
-order: 9
+order: 10
 ---
 
 # Scientific Python Stack

--- a/tech/languages/python/sphinx.md
+++ b/tech/languages/python/sphinx.md
@@ -1,7 +1,7 @@
 ---
 title: Sphinx
 subsection: python
-order: 6
+order: 9
 ---
 
 # Sphinx
@@ -11,15 +11,7 @@ order: 6
 
 ## Installation
 
-To install Sphinx on Fedora:
-
-For Python 2:
-
-```
-$ sudo dnf install python2-sphinx
-```
-
-For Python 3:
+To install Sphinx on Fedora, run:
 
 ```
 $ sudo dnf install python3-sphinx
@@ -31,12 +23,13 @@ $ sudo dnf install python3-sphinx
 Navigate your terminal into project directory and run:
 
 ```
-sphinx-quickstart
+$ sphinx-quickstart
 ```
 
 to initialize your documentation. You will be asked to choose the documentation directory, set the project name and provide some other basic information about it. Next, you will be asked which extensions you want to enable. Be sure to answer "yes" on creating Makefile for your documentation.
 
-It may happen that will miss-type some answer or you just change your mind about it. You can of course alter them whenever you want, just by editing `conf.py` file.
+It may happen that will mis-type some answer or you just change your mind about it.
+You can alter the configuration whenever you want by editing `conf.py` file.
 
 
 ## Writing your first text
@@ -49,7 +42,9 @@ Introduction
 Here goes some introduction to your project and it is all written in rst format.
 ```
 
-Now you have to open your master document, which is by default called `index.rst`. It's function is to serve welcome page and provide a table of contents for the documentation. Therefore you should add link to `introduction.rst` here:
+Now you have to open your master document, which is by default called `index.rst`.
+Its serves as a welcome page and provides a table of contents for the documentation.
+Therefore you should add link to `introduction.rst` here:
 
 ```
 .. toctree::
@@ -57,9 +52,11 @@ Now you have to open your master document, which is by default called `index.rst
 ```
 
 ## See the results
+
 Sphinx can process your content to the various output formats. Run `make help` to see all the possibilities. It should look like this:
 
 ```
+$ make help
 Please use `make <target>' where <target> is one of
   html       to make standalone HTML files
   dirhtml    to make HTML files named index.html in directories
@@ -69,7 +66,7 @@ Please use `make <target>' where <target> is one of
   ...
 ```
 
-You will probably want to use `html` for local testing purposes and `dirhtml` for deploying. You are able to test it by hitting `make html` to the command line. If Sphinx tells you that "Build finished. The HTML pages are in \_build/html", you have done it right and there is one last thing to do. Open the web browser in the current working directory (if you are not sure which one it is, just run `pwd` to make sure), navigate to the build directory that Sphinx told you (i.e. `_build/html`) and open `index.html`. I would like to introduce you to your new documentation.
+You will probably want to use `html` for local testing purposes and `dirhtml` for deploying. You are able to test it by hitting `make html` to the command line. If Sphinx tells you that "Build finished. The HTML pages are in \_build/html", all is well. Open the web browser in the current working directory (if you are not sure which one it is, just run `pwd` to make sure), navigate to the build directory that Sphinx told you (i.e. `_build/html`) and open `index.html` -- your new documentation.
 
 
 ## What next


### PR DESCRIPTION
Here's a big update to Python sections to keep them current.
The content was already reviewed by Python SIG members Zbyszek and Miro in https://github.com/encukou/content/pull/1

---

Update the list of Python versions.
Remove sections for recently removed interpreters.

Change the section order to put Multiple Pythons near the top,
since this is one of the main selling points of Fedora wrt. Python.

Warn that pip installs third-party software.

Explain more clearly why virtual environments are preferred over
Fedora packages for development.

Only keep the name "virtualenv" for environments created by the actual
`virtualenv` tool; otherwise switch "virtual environment" or just "environment".

Update Flask docs to reflect best practice there.
Add ESP32 to the MicroPython docs.

And further rewordings and reorganization.