### PR TITLE
Set npm global modules path

### DIFF
--- a/tech/languages/nodejs/nodejs.md
+++ b/tech/languages/nodejs/nodejs.md
@@ -55,3 +55,25 @@ $ yarn add request
 ## Installing npm modules
 
 Installing Node.js modules is covered in [Node.js modules](/tech/languages/nodejs/modules.html).
+
+## Installing Global Modules
+
+Create a directory for global installations inside your home directory:
+```
+mkdir ~/.npm-global
+```
+
+Set the new directory path for npm:
+```
+npm config set prefix '~/.npm-global'
+```
+
+Open/create the `~/.profile` file and add the following line:
+```
+export PATH=~/.npm-global/bin:$PATH
+```
+
+Update your system variables with this command:
+```
+source ~/.profile
+```


### PR DESCRIPTION
npm will throw an error out of the box when installing global modules like _nodemon_ etc.
I've added a solution how to set the new npm global module directory.