### PR TITLE
Update instructions for pip install

### DIFF
--- a/tech/languages/python/pypi-installation.md
+++ b/tech/languages/python/pypi-installation.md
@@ -56,15 +56,30 @@ If you no longer need it, deactivate it and delete it with `rm -rv project_venv`
 
 Sometimes, you don't want to use a virtual environment.
 For example, you're installing a tool you will use in multiple projects, but the tool is not available in Fedora repositories.
-In such cases, install with the `--user` option.
+In such cases, you might need to install `pip` if you do not already have it system-wide:
+
+```bash
+$ sudo dnf install python3-pip
+```
+
+Then, use pip's `--user` option.
 For example, to install a Python implementation of `cowsay` (rather than the original Perl one available in Fedora), run:
 
 ```bash
 $ python -m pip install --user cowsay
 ```
 
-If you're feeling lucky or impatient, you can use the shorter command `pip install cowsay`, without the `python -m`.
+If you're feeling lucky or impatient, you can use the shorter command `pip install --user cowsay`, without the `python -m`.
 Usually, this will install using the correct version of Python.
+
+## Updating packages
+
+Since software installed using `pip` are not part of Fedora, it is your responsibility to keep it updated as needed.
+However you ran `pip install`, running it again with `--update` will update to the latest release. For example:
+
+```bash
+(project_venv) $ python -m pip install --update requests
+```
 
 
 ### What next?

--- a/tech/languages/python/pypi-installation.md
+++ b/tech/languages/python/pypi-installation.md
@@ -76,7 +76,7 @@ Usually, this will install using the correct version of Python.
 
 Since software installed using `pip` is not part of Fedora, it is your responsibility to keep it updated as needed.
 However you ran `pip install`, running it again with `--update` will update to the latest release.
-For example, to update `requests` library:
+For example, to update the `requests` library:
 
 ```bash
 (project_venv) $ python -m pip install --update requests

--- a/tech/languages/python/pypi-installation.md
+++ b/tech/languages/python/pypi-installation.md
@@ -69,8 +69,6 @@ For example, to install a Python implementation of `cowsay` (rather than the ori
 $ python -m pip install --user cowsay
 ```
 
-If you're feeling lucky or impatient, you can use the shorter command `pip install --user cowsay`, without the `python -m`.
-Usually, this will install using the correct version of Python.
 
 ## Updating packages
 

--- a/tech/languages/python/pypi-installation.md
+++ b/tech/languages/python/pypi-installation.md
@@ -74,8 +74,9 @@ Usually, this will install using the correct version of Python.
 
 ## Updating packages
 
-Since software installed using `pip` are not part of Fedora, it is your responsibility to keep it updated as needed.
-However you ran `pip install`, running it again with `--update` will update to the latest release. For example:
+Since software installed using `pip` is not part of Fedora, it is your responsibility to keep it updated as needed.
+However you ran `pip install`, running it again with `--update` will update to the latest release.
+For example, to update `requests` library:
 
 ```bash
 (project_venv) $ python -m pip install --update requests


### PR DESCRIPTION
- Add pip installation. The Python 3.10 package will no longer recommend `pip`, so the tool might not always be installed system-wide. (It will still be added to new virtualenvs, however.)
- Add a section on updating packages.