### PR TITLE
Update `postgresql-setup` command

### DIFF
--- a/tech/database/postgresql/about.md
+++ b/tech/database/postgresql/about.md
@@ -27,12 +27,12 @@ server, server-compatible plug-ins and database connectors.
 PostgreSQL installation on Fedora box and basic command-line usage:
 
 ```bash
-$ sudo dnf install postgresql postgresql-server # install client/server
-$ sudo postgresql-setup initdb                  # initialize PG cluster
-$ sudo systemctl start postgresql               # start cluster
-$ sudo su - postgres                            # login as DB admin
-$ createdb quick-start                          # create testing database
-$ psql -d quick-start                           # connect to the new database
+$ sudo dnf install postgresql postgresql-server    # install client/server
+$ sudo postgresql-setup --initdb --unit postgresql # initialize PG cluster
+$ sudo systemctl start postgresql                  # start cluster
+$ sudo su - postgres                               # login as DB admin
+$ createdb quick-start                             # create testing database
+$ psql -d quick-start                              # connect to the new database
 psql (9.3.9)
 Type "help" for help.
 


### PR DESCRIPTION
When running the old command, it gives the output:

```
WARNING: using obsoleted argument syntax, try --help
WARNING: arguments transformed to: postgresql-setup --initdb --unit postgresql
```
This PR updates to the new argument syntax