### PR TITLE
mongodb-4.4.8.el8 has broken dependencies - MongoDB doesn't offer pac…

### DIFF
--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -10,6 +10,14 @@ order: 4
 
 MongoDB is a free and open source database and uses a document-oriented data model.
 
+## Security
+Fedora has determined that the Server Side Public Licensev1 (SSPL) is not a Free Software License. Therefore, we need to drop MongoDB from Fedora or never update it again. Never updating it would bring security issues, hence we decided to remove it.
+
+References:
+[MongoDB removal from Fedora](https://fedoraproject.org/wiki/Changes/MongoDB_Removal)
+[How to get MongoDB Server on Fedora](https://fedoramagazine.org/how-to-get-mongodb-server-on-fedora/)
+[See MongoDB issue ticket SERVER-58870](https://jira.mongodb.org/browse/SERVER-58870)
+
 ## Installation 
 
 ```
@@ -47,10 +55,6 @@ Now you can install with dnf
 ```
 $ sudo dnf install -y mongodb-org
 ```
-
-Version >=4.4.8 has broken dependencies for the following packages:
-mongodb-org, mongodb-org-database-tools-extra, mongodb-org-tools
-[See MongoDB issue ticket SERVER-58870](https://jira.mongodb.org/browse/SERVER-58870)
 
 ## Run mongoDB 
 

--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -48,6 +48,10 @@ Now you can install with dnf
 $ sudo dnf install -y mongodb-org
 ```
 
+Version >=4.4.8 has broken dependencies for the following packages:
+mongodb-org, mongodb-org-database-tools-extra, mongodb-org-tools
+[See MongoDB issue ticket SERVER-58870](https://jira.mongodb.org/browse/SERVER-58870)
+
 ## Run mongoDB 
 
 Start mongoDB service and after run mongoshell to test connection  


### PR DESCRIPTION
…kage support for Fedora

When installing mongodb-org on Fedora 34
Installing:
 mongodb-org                                          x86_64                     4.4.4-1.el8                            mongodb-4.4                      10 k
Installing dependencies:
 cyrus-sasl                                           x86_64                     2.1.27-8.fc34                          fedora                           69 k
 fontconfig                                           x86_64                     2.13.94-2.fc34                         updates                         273 k
 libX11                                               x86_64                     1.7.2-3.fc34                           updates                         646 k
 libX11-common                                        noarch                     1.7.2-3.fc34                           updates                         152 k
 libXau                                               x86_64                     1.0.9-6.fc34                           fedora                           31 k
 libXft                                               x86_64                     2.3.3-6.fc34                           fedora                           63 k
 libXrender                                           x86_64                     0.9.10-14.fc34                         fedora                           27 k
 libxcb                                               x86_64                     1.13.1-7.fc34                          fedora                          230 k
 mongodb-database-tools                               x86_64                     100.5.0-1                              mongodb-4.4                      47 M
 mongodb-org-mongos                                   x86_64                     4.4.4-1.el8                            mongodb-4.4                      22 M
 mongodb-org-tools                                    x86_64                     4.4.4-1.el8                            mongodb-4.4                      10 k
 python2.7                                            x86_64                     2.7.18-11.fc34                         updates                          13 M
 tix                                                  x86_64                     1:8.4.3-31.fc34                        fedora                          247 k
 tk                                                   x86_64                     1:8.6.10-6.fc34                        fedora                          1.6 M
 xml-common                                           noarch                     0.6.3-56.fc34                          fedora                           31 k
Downgrading:
 mongodb-org-server                                   x86_64                     4.4.4-1.el8                            mongodb-4.4                      28 M
 mongodb-org-shell                                    x86_64                     4.4.4-1.el8                            mongodb-4.4                      18 M
Skipping packages with broken dependencies:
 mongodb-org                                          x86_64                     4.4.8-1.el8                            mongodb-4.4                      11 k
 mongodb-org-database-tools-extra                     x86_64                     4.4.8-1.el8                            mongodb-4.4                      23 k
 mongodb-org-tools                                    x86_64                     4.4.8-1.el8                            mongodb-4.4                      11 k