### PR TITLE
vagrant-libvirt.md: QEMU / Session changes

### DIFF
--- a/tools/vagrant/vagrant-libvirt.md
+++ b/tools/vagrant/vagrant-libvirt.md
@@ -46,8 +46,8 @@ Read more on the `vagrant-libvirt` configuration in the [upstream documentation]
 
 In Fedora `qemu://session` is used by default. This allows causes vagrant to run in userspace, not requiring password and being much safer. Downside is that not all Vagrant features are accessible, as they require root. To revert for your selected boxes to `qemu://system`:
 
-- Fedora change: https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session
-- Upstream documentation: https://github.com/vagrant-libvirt/vagrant-libvirt#qemu-session-support
+- Fedora change: [https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session](https://github.com/developer-portal/content/pull/423)
+- Upstream documentation: [https://github.com/vagrant-libvirt/vagrant-libvirt#qemu-session-support](https://github.com/vagrant-libvirt/vagrant-libvirt#qemu-session-support)
 
 ## Using libvirt from Vagrant without password prompts
 

--- a/tools/vagrant/vagrant-libvirt.md
+++ b/tools/vagrant/vagrant-libvirt.md
@@ -41,6 +41,14 @@ end
 
 Read more on the `vagrant-libvirt` configuration in the [upstream documentation](https://github.com/vagrant-libvirt/vagrant-libvirt).
 
+
+## Manage guest networks via Vagrant
+
+In Fedora `qemu://session` is used by default. This allows causes vagrant to run in userspace, not requiring password and being much safer. Downside is that not all Vagrant features are accessible, as they require root. To revert for your selected boxes to `qemu://system`:
+
+- Fedora change: https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session
+- Upstream documentation: https://github.com/vagrant-libvirt/vagrant-libvirt#qemu-session-support
+
 ## Using libvirt from Vagrant without password prompts
 
 


### PR DESCRIPTION
In Fedora, QEMU / Session is used. This is not documented properly. Advice users on what it is and how to revert in case it doesn't work for them.