### PR TITLE
Replace dnf install with flatpak install for Eclipse dotNet IDE.

### DIFF
--- a/tech/languages/dotnet/dotnet-ide.md
+++ b/tech/languages/dotnet/dotnet-ide.md
@@ -7,18 +7,16 @@ order: 4
 # .NET IDEs in Fedora
 
 {: .centered .striped .highlight}
-| IDE | License | .NET Core | Mono | Debugger | Packaged in Fedora | Alternative download |
-|---|---|---|---|---|---|---|
-| [Eclipse](/tools/eclipse/about.html) with [aCute plugin](https://marketplace.eclipse.org/content/acute-c-edition-eclipse-ide-experimental) | [EPL](http://www.eclipse.org/legal/epl-2.0/) | &#x2714; | &#x2714; |  |  | [flatpak](https://download.mono-project.com/repo/monodevelop.flatpakref)<sup>1</sup> |
-| [Monodevelop](http://www.monodevelop.com/) | [LGPLv2](http://www.gnu.org/licenses/lgpl-2.1.html) |  | &#x2714; | &#x2714; | &#x2714; | [flatpak](https://download.mono-project.com/repo/monodevelop.flatpakref)<sup>1</sup> |
-| [JetBrains Rider](http://jetbrains.com/rider) | [Proprietary](https://www.jetbrains.com/store/license.html), free for [Education and OpenSource](https://www.jetbrains.com/store/#edition=discounts) | &#x2714; | &#x2714; | &#x2714; |  | tarball |
-| [Visual Studio Code](https://code.visualstudio.com) with [C# plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) | Binary is [Proprietary](https://code.visualstudio.com/License/), Source Code is [MIT](https://github.com/Microsoft/vscode/blob/master/LICENSE.txt), C# extension is [Proprietary](https://marketplace.visualstudio.com/items/ms-vscode.csharp/license) | &#x2714; |  | &#x2714; |  | [flatpak](https://flathub.org/repo/appstream/com.visualstudio.code.flatpakref)<sup>1</sup>, copr & rpm |
-
-_1. Download and install using direct link to [Flatpak](/deployment/flatpak/about.html)_
+| IDE | License | .NET Core | Mono | Debugger | Packaged in Fedora |
+|---|---|---|---|---|---|
+| [Eclipse](/tools/eclipse/about.html) with [aCute plugin](https://marketplace.eclipse.org/content/acute-c-edition-eclipse-ide-experimental) | [EPL](http://www.eclipse.org/legal/epl-2.0/) | &#x2714; | &#x2714; |  |  |
+| [Monodevelop](http://www.monodevelop.com/) | [LGPLv2](http://www.gnu.org/licenses/lgpl-2.1.html) |  | &#x2714; | &#x2714; | &#x2714; |
+| [JetBrains Rider](http://jetbrains.com/rider) | [Proprietary](https://www.jetbrains.com/store/license.html), free for [Education and OpenSource](https://www.jetbrains.com/store/#edition=discounts) | &#x2714; | &#x2714; | &#x2714; |  |
+| [Visual Studio Code](https://code.visualstudio.com) with [C# plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) | Binary is [Proprietary](https://code.visualstudio.com/License/), Source Code is [MIT](https://github.com/Microsoft/vscode/blob/master/LICENSE.txt), C# extension is [Proprietary](https://marketplace.visualstudio.com/items/ms-vscode.csharp/license) | &#x2714; |  | &#x2714; |  |
 
 ## Installing Eclipse
 
-First install Eclipse through flatpak
+First install Eclipse through [Flatpak](/deployment/flatpak/about.html)
 ```
 $ flatpak install org.eclipse.Java
 ```
@@ -37,7 +35,14 @@ $ sudo dnf install monodevelop
 
 ## Installing Visual Studio Code
 
-Download [Visual Studio Code](https://code.visualstudio.com) and the C# Extension from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+[Visual Studio Code](https://code.visualstudio.com) is available:
+  * as an RPM downloadable from their website.
+  * as a [Flatpak](/deployment/flatpak/about.html) package installable like so:
+  ```
+  $ flatpak install com.visualstudio.code
+  ```
+
+After installing Visual Studio Code you can install the C# Extension from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
 
 Alternatively use the [VSCodium](https://vscodium.com/) for Free/Libre Open Source Software Binaries of VSCode.
 

--- a/tech/languages/dotnet/dotnet-ide.md
+++ b/tech/languages/dotnet/dotnet-ide.md
@@ -9,18 +9,18 @@ order: 4
 {: .centered .striped .highlight}
 | IDE | License | .NET Core | Mono | Debugger | Packaged in Fedora | Alternative download |
 |---|---|---|---|---|---|---|
-| [Eclipse](/tools/eclipse/about.html) with [aCute plugin](https://marketplace.eclipse.org/content/acute-c-edition-eclipse-ide-experimental) | [EPL](http://www.eclipse.org/legal/epl-2.0/) | &#x2714; | &#x2714; |  | &#x2714; |  |
+| [Eclipse](/tools/eclipse/about.html) with [aCute plugin](https://marketplace.eclipse.org/content/acute-c-edition-eclipse-ide-experimental) | [EPL](http://www.eclipse.org/legal/epl-2.0/) | &#x2714; | &#x2714; |  |  | [flatpak](https://download.mono-project.com/repo/monodevelop.flatpakref)<sup>1</sup> |
 | [Monodevelop](http://www.monodevelop.com/) | [LGPLv2](http://www.gnu.org/licenses/lgpl-2.1.html) |  | &#x2714; | &#x2714; | &#x2714; | [flatpak](https://download.mono-project.com/repo/monodevelop.flatpakref)<sup>1</sup> |
 | [JetBrains Rider](http://jetbrains.com/rider) | [Proprietary](https://www.jetbrains.com/store/license.html), free for [Education and OpenSource](https://www.jetbrains.com/store/#edition=discounts) | &#x2714; | &#x2714; | &#x2714; |  | tarball |
 | [Visual Studio Code](https://code.visualstudio.com) with [C# plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) | Binary is [Proprietary](https://code.visualstudio.com/License/), Source Code is [MIT](https://github.com/Microsoft/vscode/blob/master/LICENSE.txt), C# extension is [Proprietary](https://marketplace.visualstudio.com/items/ms-vscode.csharp/license) | &#x2714; |  | &#x2714; |  | [flatpak](https://flathub.org/repo/appstream/com.visualstudio.code.flatpakref)<sup>1</sup>, copr & rpm |
 
-_1. Download and install using direct link to [Flatpak](/deployment/Flatpak/about.html)_
+_1. Download and install using direct link to [Flatpak](/deployment/flatpak/about.html)_
 
 ## Installing Eclipse
 
-First install Eclipse and Eclipse Marketplace
+First install Eclipse through flatpak
 ```
-$ sudo dnf install eclipse eclipse-mpc
+$ flatpak install org.eclipse.Java
 ```
 then install the aCute extension from the [Marketplace](https://marketplace.eclipse.org/content/acute-c-edition-eclipse-ide-experimental)
 


### PR DESCRIPTION
Eclipse was retired in Fedora 35, therefore it is not installable through
DNF.

Resolves: https://github.com/developer-portal/content/issues/407

Fix link in dotNet to flatpak pages.

Resolves: https://github.com/developer-portal/content/issues/427

Tested locally. I was able to install and run a smoke test of the aCute extension.