### PR TITLE
Update Java sections

### DIFF
--- a/tech/languages/java/java-build-tools-installation.md
+++ b/tech/languages/java/java-build-tools-installation.md
@@ -18,7 +18,7 @@ $ sudo dnf install maven
 
 ## Ant+Ivy installation
 
-Last but not least, still quite popular duo [Ant+Ivy](http://ant.apache.org/ivy/) can be installed simply by typing:
+Last but not least, still quite popular duo [Ant+Ivy](https://ant.apache.org/ivy/) can be installed simply by typing:
 
 ```
 $ sudo dnf install ant apache-ivy
@@ -34,7 +34,7 @@ Use the command from the [Maven quick start guide](https://maven.apache.org/guid
 $ mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app -DarchetypeArtifactId=maven-archetype-quickstart -DarchetypeVersion=1.4 -DinteractiveMode=false
 ```
 
-The project that is created follows the [Maven Project Structure](http://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html). Initially you should see the `src` directory when you explore the project directory. You will also notice that your project directory has a file, the [pom.xml](https://maven.apache.org/pom.html) in it, this is your Maven project file that defines your build, and how you will transition through the Maven build [lifecycles](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html). 
+The project that is created follows the [Maven Project Structure](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html). Initially you should see the `src` directory when you explore the project directory. You will also notice that your project directory has a file, the [pom.xml](https://maven.apache.org/pom.html) in it, this is your Maven project file that defines your build, and how you will transition through the Maven build [lifecycles](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html).
 
 The sample application created by the Maven archetype contains a single "Hello World" application (jar).
 
@@ -56,14 +56,10 @@ $ git init
 
 If you run `git status` in the created `my-app` directory, you will see that the `target` directory is still part of your git repository. It is a best practice not to include this in your version control system, so it is recommended that you create a [gitignore](https://git-scm.com/docs/gitignore) file, add this directory and anything under it as ignored files.
 
-A good starter `.gitignore` file for Maven projects can be found on [Github](https://github.com/github/gitignore/blob/master/Maven.gitignore). Download it into your repo with:
+A good starter `.gitignore` file for Maven projects can be found on [Github](https://github.com/github/gitignore/blob/main/Maven.gitignore). Download it into your repo with:
 
 ```
-$ curl https://raw.githubusercontent.com/github/gitignore/master/Maven.gitignore -o .gitignore
+$ curl https://raw.githubusercontent.com/github/gitignore/main/Maven.gitignore -o .gitignore
 ```
 
-The `src` directory is the start of your source directory structure, and under this directory you will see typically see any number of [package directories](http://docs.oracle.com/javase/tutorial/java/package/managingfiles.html) (example: `main`). If you have tests, you will find them in the `test` directory.
-
-
-
-<!-- TODO: once content for Scala programming language is created, mention here that it's also possible to use SBT to build Java projects + link to corresponding Scala section. -->
+The `src` directory is the start of your source directory structure, and under this directory you will see typically see any number of [package directories](https://docs.oracle.com/javase/tutorial/java/package/managingfiles.html) (example: `main`). If you have tests, you will find them in the `test` directory.

--- a/tech/languages/java/java-installation.md
+++ b/tech/languages/java/java-installation.md
@@ -8,26 +8,18 @@ description: General-purpose, object-oriented and concurrent computer programmin
 
 # Java installation
 
-Fedora comes with [OpenJDK](http://openjdk.java.net/) - a free and open source implementation of the Java Platform, Standard Edition. To install it, simply type:
+Fedora comes with [OpenJDK](https://openjdk.java.net/) - a free and open source implementation of the Java Platform, Standard Edition. To install it, simply type:
 
 ```
-$ sudo dnf install java-15-openjdk-devel
+$ sudo dnf install java-openjdk-devel
 ```
 
 This command will install Java Development Kit - runtime environment and associated development tools.
 
-[IcedTea-Web](http://icedtea.classpath.org/wiki/IcedTea-Web) may come handy if your plan is to develop Java applets or to experiment with Java Web Start. To install it, simply type:
-
-```
-$ sudo dnf install icedtea-web
-```
-
-This command will install Java web browser plugin and free implementation of Java Web Start.
-
 Later, when you will want to test your new application in a production-like environment, it's possible to install just Java runtime environment (JRE) - without development tools. This can be achieved by several means:
 
 ```
-$ sudo dnf install java-15-openjdk-headless
+$ sudo dnf install java-openjdk-headless
 ```
 
 The command above will install so-called "headless" JRE, i.e. JRE without support for graphic and audio. If your application is supposed to run on a server without any graphical user interface (GUI) installed, then this is likely what you want.
@@ -35,7 +27,7 @@ The command above will install so-called "headless" JRE, i.e. JRE without suppor
 However, if your application needs support for GUI or audio, you will likely want to install full JRE. You can do that simply by typing:
 
 ```
-$ sudo dnf install java-15-openjdk
+$ sudo dnf install java-openjdk
 ```
 
 <!-- TODO: add section about installing JDK from 3rd parties + how to switch between them -->

--- a/tech/languages/java/java-installation.md
+++ b/tech/languages/java/java-installation.md
@@ -11,7 +11,7 @@ description: General-purpose, object-oriented and concurrent computer programmin
 Fedora comes with [OpenJDK](https://openjdk.java.net/) - a free and open source implementation of the Java Platform, Standard Edition. To install it, simply type:
 
 ```
-$ sudo dnf install java-openjdk-devel
+$ sudo dnf install java-devel
 ```
 
 This command will install Java Development Kit - runtime environment and associated development tools.


### PR DESCRIPTION
Update Java sections
- OpenJDK 15 is no longer available, use geniric, unversioned virtual package names.
- IcedTea-Web is retired.
- Use https links instead of http.
- Some git branches were renamed from master to main.