### PR TITLE
Update Go documentation

### DIFF
--- a/tech/languages/go/go-packages.md
+++ b/tech/languages/go/go-packages.md
@@ -8,15 +8,19 @@ order: 3
 
 ## Go packages from upstream
 
-Upstream projects can be installed with `go get` command. Package names follows the import paths so to install `github.com/gorilla/context` from GitHub run:
+Upstream projects can be installed with `go install` command, but only if they have `main` package. Package names follows the import paths so to install `github.com/go-delve/delve` from GitHub you need to reference the `main` package with a suffix like `@v1.2.3` or `@latest` run:
 
-```
-$ go get github.com/gorilla/context
+```console
+# Install a specific version.
+$ go install github.com/go-delve/delve/cmd/dlv@v1.8.2
+
+# Install the highest available version.
+$ go install github.com/go-delve/delve/cmd/dlv@latest
 ```
 
-If the requested package comes with an executable binary, you will find it in `$GOPATH/bin`. If you have not added that to your `PATH` environment variable yet, you can do so with these commands:
+This will build and install the binary in `$GOPATH/bin`. If you have not added that to your `PATH` environment variable yet, you can do so with these commands:
 
-```
+```console
 $ echo 'export PATH=$PATH:$GOPATH/bin' >> $HOME/.bashrc
 $ source $HOME/.bashrc
 ```
@@ -29,6 +33,10 @@ The package name idiom is that the import paths of libraries are fully qualified
 
 To install `golang-googlecode-net-devel` package, you use DNF as usual:
 
-```
+```console
 $ sudo dnf install golang-googlecode-net-devel
 ```
+
+## References
+
+- [Go Documentation: Deprecation of go get](https://go.dev/doc/go-get-install-deprecation)

--- a/tech/languages/go/go-programs.md
+++ b/tech/languages/go/go-programs.md
@@ -35,13 +35,18 @@ $ go run hello.go
 Hello, Fedora!
 ```
 
-The command `go run` builds and runs a Go program, and is useful for quick experiments.
-To build the program and generate a compiled binary, use `go build`:
+The command `go run` compiles and runs the named main Go program, and is useful for quick experiments.
+To build the program along with the dependencies, you need to configure the modules first, and use `go build`:
 
 ```console
+$ go mod init
+go: creating new go.mod: module hello
+go: to add module requirements and sums:
+	go mod tidy
+$ go mod tidy
 $ go build
 $ ls
-hello  hello.go
+go.mod  hello  hello.go
 ```
 
 Without arguments, `go build` builds the package in the current directory, and in case of a main package it places a binary in the same directory. Let's try it:
@@ -51,7 +56,7 @@ $ ./hello
 Hello, Fedora!
 ```
 
-Yet another option is to use `go install`:
+Yet another option is to use `go install`. You still need to configure the modules as it was detailed before:
 
 ```console
 $ go install
@@ -71,3 +76,7 @@ $ source $HOME/.bashrc
 $ hello
 Hello, Fedora!
 ```
+
+## References
+
+- [Go Documentation: Create a Go module](https://go.dev/doc/tutorial/create-module)


### PR DESCRIPTION
Few things have changed and modules are now a critical part of the process.

I also changed the `github.com/gorilla/context` project for `github.com/go-delve/delve` because it is deprecated and doesn't work anymore. Delve is the _de facto_ debugger so seems like a good example.