### PR TITLE
Draft: Update MongoDB installation and remove MongoDB GUI

### DIFF
--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -51,7 +51,3 @@ $ mongo
 MongoDB shell version: 4.0.0
 connecting to: test
 ```
-
-## MongoDB GUI (not tested)
-
-[MongoDB Admin](https://github.com/hatamiarash7/MongoDB_Admin/wiki/1.-Getting-Start) is a Cross Platform GUI.

--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -41,6 +41,8 @@ Now you can install with dnf
 $ sudo dnf install -y mongodb-org
 ```
 
+**Warning:** MongoDB does not guarantee compatibility with Fedora Linux, so newer MongoDB server packages might fail to install. [See MongoDB issue ticket SERVER-58871](https://jira.mongodb.org/browse/SERVER-58870).
+
 ## Run mongoDB 
 
 Start mongoDB service and after run mongoshell to test connection  

--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -8,27 +8,20 @@ order: 4
 
 # MongoDB 
 
-MongoDB is a free and open source database and uses a document-oriented data model.
-
-## Installation 
-
-```
-# dnf install mongodb mongodb-server
-# service mongod start
-```
+Mongo (from “humongous”) is a high-performance, open source, schema-free document-oriented database, which is one of the most favorite so-called NoSQL databases. It uses JSON as a document format, and it is designed to be scalable and replicable across multiple server nodes.
 
 ## How to install a specific version 
 
 First we need configure the package management system, please note that:
 
-> DNF by default uses the global configuration file at /etc/dnf/dnf.conf and all *.repo files found under /etc/yum.repos.d. The
+> DNF by default uses the global configuration file at /etc/dnf/dnf.conf and all \*.repo files found under /etc/yum.repos.d. The
 latter is typically used for repository configuration and takes precedence over global configuration.
 
 Access the directory and create a file mongodb-org-*release_series*.repo
 
-```
+```console
 $ cd /etc/yum.repos.d/
-$ sudo touch mongodb-org-4.4.repo  
+$ sudo touch mongodb-org-4.4.repo
 ```
 
 Insert this content inside mongodb-org-*release_series*.repo, edit if you want install another version.
@@ -44,7 +37,7 @@ gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc
 
 Now you can install with dnf
 
-```
+```console
 $ sudo dnf install -y mongodb-org
 ```
 
@@ -52,8 +45,8 @@ $ sudo dnf install -y mongodb-org
 
 Start mongoDB service and after run mongoshell to test connection  
 
-```
-$ sudo service mongod start
+```console
+$ sudo systemctl start mongod.service
 $ mongo
 MongoDB shell version: 4.0.0
 connecting to: test


### PR DESCRIPTION
It is not installable from Fedora since Fedora 30, but using the repo file seem to function OK.
Also update steps for enabling the systemd service.

MongoDB GUI repo is archived and I do not know of an alternative 