### PR TITLE
Deprecate groovy-installation.md.

### DIFF
--- a/tech/languages/groovy/groovy-installation.md
+++ b/tech/languages/groovy/groovy-installation.md
@@ -1,10 +1,13 @@
 ---
 title: Groovy
 subsection: groovy
+section: tech-languages
 order: 1
-section: Powerful, optionally typed and dynamic language with static compilation capabilities on JVM.
-description:
+version: 2.4.8
+description: Powerful, optionally typed and dynamic language with static compilation capabilities on JVM.
 ---
+
+{% include content-deprecation.html %}
 
 # Groovy installation
 


### PR DESCRIPTION
Groovy is not available in Fedora since October 2019

Resolves: https://github.com/developer-portal/content/issues/421