### PR TITLE
Deprecate Cassandra page due to lack of maintanance.

### DIFF
--- a/tech/database/cassandra/about.md
+++ b/tech/database/cassandra/about.md
@@ -5,6 +5,8 @@ section: tech-database
 description: OpenSource database server for high-scale application.
 ---
 
+{% include content-deprecation.html %}
+
 # Apache Cassandra
 
 The Apache Cassandra database is the right choice when you need scalability and


### PR DESCRIPTION
Cassandra is not available on Fedora and
the page wasn't updated in a long time and contains quite an outdated content.