### PR TITLE
MongoDB deprecation

### DIFF
--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -6,6 +6,8 @@ description: Document-oriented and NoSQL database
 order: 4
 ---
 
+{% include content-deprecation.html %}
+
 # MongoDB 
 
 MongoDB is a free and open source database and uses a document-oriented data model.

--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -10,29 +10,27 @@ order: 4
 
 MongoDB is a free and open source database and uses a document-oriented data model.
 
-## Installation 
+## Security
 
-```
-# dnf install -y mongodb-org
-# systemctl enable mongod.service
-# systemctl start mongod.service
-```
+Fedora has determined that the Server Side Public Licensev1 (SSPL) is not a Free Software License. Therefore, we need to drop MongoDB from Fedora or never update it again. Never updating it would bring security issues, hence we decided to remove it.
 
-## How to install a specific version 
+References:
+* [MongoDB removal from Fedora](https://fedoraproject.org/wiki/Changes/MongoDB_Removal)
+
+## How to install a specific upstream version
 
 First we need configure the package management system, please note that:
 
-> DNF by default uses the global configuration file at /etc/dnf/dnf.conf and all *.repo files found under /etc/yum.repos.d. The
+> DNF by default uses the global configuration file at /etc/dnf/dnf.conf and all \*.repo files found under /etc/yum.repos.d. The
 latter is typically used for repository configuration and takes precedence over global configuration.
 
-Access the directory and create a file mongodb-org-*release_series*.repo
+Create a file mongodb-org-*release_series*.repo
 
-```
-$ cd /etc/yum.repos.d/
-$ sudo touch mongodb-org-4.4.repo  
+```console
+$ sudo nano /etc/yum.repos.d/mongodb-org-4.4.repo
 ```
 
-Insert this content inside mongodb-org-*release_series*.repo, edit if you want install another version.
+Insert this content inside the mongodb-org-*release_series*.repo file, edit the *release_series* in the filename and the baseurl and gpgkey fields URLs if you want to install another version.
 
 ```
 [Mongodb]
@@ -45,28 +43,34 @@ gpgkey=https://www.mongodb.org/static/pgp/server-4.4.asc
 
 Now you can install with dnf
 
-```
-$ sudo dnf install -y mongodb-org
+```console
+$ sudo dnf install mongodb-org
 ```
 
-## Enable mongoDB services 
+Currently some packages do not install, however those packages do not affect the functionality of MongoDB.
 
-Start mongoDB service and after run mongoshell to test connection  
+**Warning:** MongoDB does not guarantee compatibility with Fedora Linux, so newer MongoDB server packages might fail to install. [See MongoDB issue ticket SERVER-58871](https://jira.mongodb.org/browse/SERVER-58870).
 
-```
+## Enable MongoDB services
+
+To enable and start MongoDB service run:
+
+```console
 $ sudo systemctl enable mongod.service
 $ sudo systemctl start mongod.service
 ```
 
-## Check mongoDB current status
+## Check MongoDB current status
 
-```
+```console
 $ sudo systemctl status mongod.service
 ```
 
-## Run mongodb
+## Test MongoDB connection
 
-```
+Run mongoshell to test the connection:
+
+```console
 $ mongo
 MongoDB shell version: 4.0.0
 connecting to: test

--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -13,8 +13,9 @@ MongoDB is a free and open source database and uses a document-oriented data mod
 ## Installation 
 
 ```
-# dnf install mongodb mongodb-server
-# service mongod start
+# dnf install -y mongodb-org
+# systemctl enable mongod.service
+# systemctl start mongod.service
 ```
 
 ## How to install a specific version 
@@ -48,12 +49,24 @@ Now you can install with dnf
 $ sudo dnf install -y mongodb-org
 ```
 
-## Run mongoDB 
+## Enable mongoDB services 
 
 Start mongoDB service and after run mongoshell to test connection  
 
 ```
-$ sudo service mongod start
+$ sudo systemctl enable mongod.service
+$ sudo systemctl start mongod.service
+```
+
+## Check mongoDB current status
+
+```
+$ sudo systemctl status mongod.service
+```
+
+## Run mongodb
+
+```
 $ mongo
 MongoDB shell version: 4.0.0
 connecting to: test


### PR DESCRIPTION
This is mostly based on the suggestions and content from this PR: https://github.com/developer-portal/content/pull/321

It is the last content update to attempt to bring a more current, at least partially working approach (99% working last I checked, but I do not have any realworld use case, so I cannot test the full extent), and with some fixups to better adhere to the Fedora Developer Portal content guide.

This will be accompanied by an email to fedora-devel calling for contributors once I collect all the components that suffer from similarly out-of-date content.

@pvalena PTAL,  IIRC, these steps have worked for 4.4 since I tested it around a month ago.