### PR TITLE
Removed unsupported versions and added current .NET Core versions

### DIFF
--- a/tech/languages/dotnet/about.md
+++ b/tech/languages/dotnet/about.md
@@ -20,13 +20,6 @@ permalink: /tech/languages/csharp/dotnet-installation.html
 $ sudo dnf install dotnet
 ```
 
-For older versions of Fedora and .NET Core 2.1, add the .NET SIG's [copr repository](/deployment/copr/about.html) repository and install the `dotnet-sdk-2.1` package.
-
-```
-$ sudo dnf copr enable @dotnet-sig/dotnet
-$ sudo dnf install dotnet-sdk-2.1
-```
-
 It is not advised to mix these packages with those provided by Microsoft, please disable any other repositories providing dotnet before installing these.
 
 See the [.NET Core](dotnetcore.html) page for more information.

--- a/tech/languages/dotnet/about.md
+++ b/tech/languages/dotnet/about.md
@@ -20,8 +20,6 @@ permalink: /tech/languages/csharp/dotnet-installation.html
 $ sudo dnf install dotnet
 ```
 
-It is not advised to mix these packages with those provided by Microsoft, please disable any other repositories providing dotnet before installing these.
-
 See the [.NET Core](dotnetcore.html) page for more information.
 
 ## Mono

--- a/tech/languages/dotnet/dotnetcore.md
+++ b/tech/languages/dotnet/dotnetcore.md
@@ -7,7 +7,7 @@ version: 7.8.4
 
 ## .NET Core Installation
 
-### .NET Core 6
+### .NET Core 6 and 7
 
 .NET Core 6 and 7 is included in Fedora 36 and 37 Simply install it using one of the below variants:
 

--- a/tech/languages/dotnet/dotnetcore.md
+++ b/tech/languages/dotnet/dotnetcore.md
@@ -7,9 +7,9 @@ version: 7.8.4
 
 ## .NET Core Installation
 
-### .NET Core 3.1
+### .NET Core 6
 
-.NET Core 3.1 is included in Fedora 32 (and later versions.) Simply install it using one of the below variants:
+.NET Core 6 and 7 is included in Fedora 36 and 37 Simply install it using one of the below variants:
 
 Install the latest SDK:
 ```
@@ -17,9 +17,10 @@ $ sudo dnf install dotnet
 ```
 
 Or a specific version:
+### Install .NET Core 6 SDK
+
 ```
-# Install .NET Core 3.1 SDK
-$ sudo dnf install dotnet-sdk-3.1
+$ sudo dnf install dotnet-sdk-6.0
 ```
 
 To install runtime only, for example to merely deploy already prebuilt applications, where _x_ stands for major and _y_ stands for minor version:

--- a/tech/languages/dotnet/dotnetcore.md
+++ b/tech/languages/dotnet/dotnetcore.md
@@ -7,8 +7,6 @@ version: 7.8.4
 
 ## .NET Core Installation
 
-It is not advised to mix these packages with those provided by Microsoft, please disable any other repositories providing dotnet before installing these.
-
 ### .NET Core 3.1
 
 .NET Core 3.1 is included in Fedora 32 (and later versions.) Simply install it using one of the below variants:

--- a/tech/languages/dotnet/dotnetcore.md
+++ b/tech/languages/dotnet/dotnetcore.md
@@ -9,14 +9,6 @@ version: 7.8.4
 
 It is not advised to mix these packages with those provided by Microsoft, please disable any other repositories providing dotnet before installing these.
 
-### .NET Core 2.1
-
-.NET Core 2.1 is not packaged in the proper Fedora repository and an extra step to enable the .NET SIG's [copr repository](/deployment/copr/about.html) repository is required:
-
-```
-$ sudo dnf copr enable @dotnet-sig/dotnet
-```
-
 ### .NET Core 3.1
 
 .NET Core 3.1 is included in Fedora 32 (and later versions.) Simply install it using one of the below variants:


### PR DESCRIPTION
Versions 3.1 and 2.1 are no longer supported by Microsoft, they were replaced by the versions that are still supported.

More information in https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core.

The texts about not mixing Microsoft versions with Fedora versions were removed, since Microsoft stopped providing .NET Core versions for Fedora Linux.