### PR TITLE
Update .NET docs for .NET 7 release

### DIFF
--- a/tech/languages/dotnet/about.md
+++ b/tech/languages/dotnet/about.md
@@ -24,7 +24,7 @@ Where `x.y` is a .NET version number, like `7.0` or `6.0`.
 
 It is not advised to mix these packages with those provided by Microsoft. Please disable any other repositories providing dotnet before installing these. If you run into any errors that refer to `/usr/share/dotnet` or a missing `libhostfxr.so` see [troubleshoot .NET errors related to missing files on Linux](https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup) which describes how to fix the errors.
 
-See the [.NET](dotnetcore.html) page for more information.
+See the [.NET](../dotnet/dotnetcore.html) page for more information.
 
 ## Mono
 

--- a/tech/languages/dotnet/about.md
+++ b/tech/languages/dotnet/about.md
@@ -4,32 +4,27 @@ subsection: dotnet
 section: tech-languages
 order: 1
 version: 7.8.4
-description: ".NET Core and Mono are open-source .NET platforms. .NET applications are developed using the C#, F# and VB.NET programming languages."
+description: ".NET and Mono are open-source .NET platforms. .NET applications are developed using the C#, F# and VB.NET programming languages."
 permalink: /tech/languages/csharp/dotnet-installation.html
 ---
 
-.NET Core and Mono are available on Fedora. .NET applications are developed using the C#, F# and VB.NET programming languages.
+.NET (and .NET Core) and Mono are available on Fedora. .NET applications are developed using the C#, F# and VB.NET programming languages.
 
-## .NET Core
+## .NET (and .NET Core)
 
-[.NET Core](https://docs.microsoft.com/en-us/dotnet/core/) is a general-purpose, modular, cross-platform and open-source development Platform.
+[.NET](https://docs.microsoft.com/en-us/dotnet/core/) is a general-purpose, modular, cross-platform and open-source development Platform.
 
-.NET Core 3.1 and later versions are packaged in Fedora since 32. Installing the latest SDK can be done with a simple
-
-```
-$ sudo dnf install dotnet
-```
-
-For older versions of Fedora and .NET Core 2.1, add the .NET SIG's [copr repository](/deployment/copr/about.html) repository and install the `dotnet-sdk-2.1` package.
+.NET 7 and .NET 6 are available in all supported versions of Fedora. Installing an SDK can be done with a simple
 
 ```
-$ sudo dnf copr enable @dotnet-sig/dotnet
-$ sudo dnf install dotnet-sdk-2.1
+$ sudo dnf install dotnet-sdk-x.y
 ```
 
-It is not advised to mix these packages with those provided by Microsoft, please disable any other repositories providing dotnet before installing these.
+Where `x.y` is a .NET version number, like `7.0` or `6.0`.
 
-See the [.NET Core](dotnetcore.html) page for more information.
+It is not advised to mix these packages with those provided by Microsoft. Please disable any other repositories providing dotnet before installing these. If you run into any errors that refer to `/usr/share/dotnet` or a missing `libhostfxr.so` see [troubleshoot .NET errors related to missing files on Linux](https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup) which describes how to fix the errors.
+
+See the [.NET](dotnetcore.html) page for more information.
 
 ## Mono
 

--- a/tech/languages/dotnet/about.md
+++ b/tech/languages/dotnet/about.md
@@ -8,9 +8,9 @@ description: ".NET and Mono are open-source .NET platforms. .NET applications ar
 permalink: /tech/languages/csharp/dotnet-installation.html
 ---
 
-.NET (and .NET Core) and Mono are available on Fedora. .NET applications are developed using the C#, F# and VB.NET programming languages.
+.NET, .NET Core and Mono are available on Fedora. .NET applications are developed using the C#, F# and VB.NET programming languages.
 
-## .NET (and .NET Core)
+## .NET and .NET Core
 
 [.NET](https://docs.microsoft.com/en-us/dotnet/core/) is a general-purpose, modular, cross-platform and open-source development Platform.
 

--- a/tech/languages/dotnet/dotnetcore.md
+++ b/tech/languages/dotnet/dotnetcore.md
@@ -1,40 +1,76 @@
 ---
-title: .NET Core
+title: .NET
 subsection: dotnet
 order: 2
 version: 7.8.4
 ---
 
-## .NET Core Installation
+## .NET Installation
 
-It is not advised to mix these packages with those provided by Microsoft, please disable any other repositories providing dotnet before installing these.
+.NET packages are available in Fedora repositories.
 
-### .NET Core 2.1
+It is not advised to mix these packages with those provided by Microsoft. Please disable any other repositories providing dotnet before installing these. If you run into errors, see [troubleshooting linux package mixup](https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup) for some suggestions on how to fix the issue.
 
-.NET Core 2.1 is not packaged in the proper Fedora repository and an extra step to enable the .NET SIG's [copr repository](/deployment/copr/about.html) repository is required:
+To install a .NET SDK only, run this command, where _x_ stands for major and _y_ stands for minor version:
 
 ```
-$ sudo dnf copr enable @dotnet-sig/dotnet
+$ sudo dnf install dotnet-sdk-x.y
 ```
 
-### .NET Core 3.1
+To install the ASP.NET Core Runtime only, for example to deploy an already built ASP.NET Core applications, where _x_ stands for major and _y_ stands for minor version:
 
-.NET Core 3.1 is included in Fedora 32 (and later versions.) Simply install it using one of the below variants:
-
-Install the latest SDK:
 ```
-$ sudo dnf install dotnet
+$ sudo dnf install aspnetcore-runtime-x.y
 ```
 
-Or a specific version:
-```
-# Install .NET Core 3.1 SDK
-$ sudo dnf install dotnet-sdk-3.1
-```
+To install runtime only, for example to merely deploy an already built (non ASP.NET Core) applications, where _x_ stands for major and _y_ stands for minor version:
 
-To install runtime only, for example to merely deploy already prebuilt applications, where _x_ stands for major and _y_ stands for minor version:
 ```
 $ sudo dnf install dotnet-runtime-x.y
+```
+
+### .NET 7
+
+.NET 7 is a Standard Term Support release and will reach its End of Life in May 2024.
+
+Install the .NET 7 SDK:
+
+```
+$ sudo dnf install dotnet-sdk-7.0
+```
+
+Install the ASP.NET Core 7 Runtime:
+
+```
+$ sudo dnf install aspnetcore-runtime-7.0
+```
+
+Install the .NET 7 Runtime:
+
+```
+$ sudo dnf install dotnet-runtime-7.0
+```
+
+### .NET 6
+
+.NET 6 is a Long Term Support release and will reach its End of Life in November 2024.
+
+Install the .NET 6 SDK:
+
+```
+$ sudo dnf install dotnet-sdk-6.0
+```
+
+Install the ASP.NET Core 6 Runtime:
+
+```
+$ sudo dnf install aspnetcore-runtime-6.0
+```
+
+Install the .NET 6 Runtime:
+
+```
+$ sudo dnf install dotnet-runtime-6.0
 ```
 
 ### Preview versions
@@ -44,6 +80,8 @@ Preview packages can be installed after enabling the preview [copr repository](/
 $ sudo dnf copr enable @dotnet-sig/dotnet-preview
 $ sudo dnf install dotnet-sdk-x.y
 ```
+
+Please note that these preview packages aren't fully tested. They may contain bugs and may destroy data.
 
 ## Getting Started
 


### PR DESCRIPTION
.NET Core has reached its End of Life. Upstream also did a rename from .NET Core to .NET for the 5.0 release. The only supported versions of .NET are now 6.0 and 7.0.