### PR TITLE
Add Dune section in OCaml content

### DIFF
--- a/tech/languages/ocaml/dune.md
+++ b/tech/languages/ocaml/dune.md
@@ -6,7 +6,7 @@ order: 2
 
 # Dune
 
-Dune is a build system for OCaml. It provides a comprehensive and uniform interface for the building, testing, and installation of OCaml projects, making it incredibly easy for developers to manage dependencies between packages. Its primary focus is to offer simplicity, speed, and ease of use, making it a suitable solution for even the most complex and extensive OCaml projects. With Dune, you can enjoy the benefits of incremental builds, which result in faster build times by recompiling only the necessary files. Moreover, Dune makes it convenient to generate optimized native code and perform static analysis, contributing to the development of high-performance and reliable OCaml applications.
+Dune is a build system for OCaml. It provides a comprehensive and uniform interface for the building, testing, and intalling OCaml projects, making it incredibly easy for developers to manage dependencies between packages. Its primary focus is to offer simplicity, speed, and ease of use, making it a suitable solution for even the most complex and extensive OCaml projects. With Dune, you can enjoy the benefits of incremental builds, which result in faster build times by recompiling only the necessary files. Moreover, Dune makes it convenient to generate optimized native code and perform static analysis, contributing to the development of high-performance and reliable OCaml applications.
 
 ## Install
 

--- a/tech/languages/ocaml/dune.md
+++ b/tech/languages/ocaml/dune.md
@@ -20,36 +20,36 @@ $ opam install dune
 
 ## Starting a new Project
 
-1. Create a new directory for your project.
+Create a new directory for your project.
 
 ```console
 $ mkdir yourprojectname
 ```
 
-2. To initialize a Dune project change into the new directory and run the following command:
+To initialize a Dune project change into the new directory and run the following command:
 
 ```console
 $ cd yourprojectname
 $ dune init
 ```
 
-3. This will create the necessary files and directories for a basic Dune project, including a `dune` file and a `src` directory.
+This will create the necessary files and directories for a basic Dune project, including a `dune` file and a `src` directory.
 
 ## Building the project
 
-1. Change into the **root** directory of your project.
-2. Run the following command to build the project:
+Change into the **root** directory of your project.
+Run the following command to build the project:
 
 ```console
 $ dune build
 ```
 
-3. Dune will compile the source files and generate the necessary executables.
+Dune will compile the source files and generate the necessary executables.
 
 ## Running the project
 
-1. Change into the **root** directory of your project.
-2. Run the following command to run the main executable:
+Change into the **root** directory of your project.
+Run the following command to run the main executable:
 
 ```console
 $ dune exec ./bin/your-executable.exe
@@ -58,25 +58,25 @@ $ dune exec ./bin/your-executable.exe
 
 ## Adding a library to project
 
-1. First, make sure you have the required library installed. You can use the following command to install a library using Opam:
+First, make sure you have the required library installed. You can use the following command to install a library using Opam:
 
 ```console
 $ opam install library-name
 ```
 
-2. Open the `dune` file in your project's root directory.
-3. Add the following line to the `(library ...)` section to include the library:
+Open the `dune` file in your project's root directory.
+Add the following line to the `(library ...)` section to include the library:
 
 ```dune
 (libraries library-name)
 ```
 
-4. Replace `library-name` with the actual name of the library you want to add.
-5. Save and close the `dune` file.
-6. Rebuild the project using the following command:
+Replace `library-name` with the actual name of the library you want to add.
+Save and close the `dune` file.
+Rebuild the project using the following command:
 
 ```console
 $ dune build
 ```
 
-7. The added library should now be available for use in your project.
+The added library should now be available for use in your project.

--- a/tech/languages/ocaml/dune.md
+++ b/tech/languages/ocaml/dune.md
@@ -1,0 +1,80 @@
+---
+title: Dune
+subsection: ocaml
+order: 2
+---
+
+# Dune
+
+Dune is a build system for OCaml. It provides a comprehensive and uniform interface for the building, testing, and installation of OCaml projects, making it incredibly easy for developers to manage dependencies between packages. Its primary focus is to offer simplicity, speed, and ease of use, making it a suitable solution for even the most complex and extensive OCaml projects. With Dune, you can enjoy the benefits of incremental builds, which result in faster build times by recompiling only the necessary files. Moreover, Dune makes it convenient to generate optimized native code and perform static analysis, contributing to the development of high-performance and reliable OCaml applications.
+
+## Install
+
+You can install Dune with OPAM that we installed in the enviroment setup. For do it just run:
+
+```console
+$ opam install dune
+```
+
+## Starting a new Project
+
+1. Create a new directory for your project.
+
+```console
+$ mkdir yourprojectname
+```
+
+2. Change into the new directory and run the following command to initialize a Dune project:
+
+```console
+$ cd yourprojectname
+$ dune init
+```
+
+3. This will create the necessary files and directories for a basic Dune project, including a `dune` file and a `src` directory.
+
+## Building the project
+
+1. Change into the **root** directory of your project.
+2. Run the following command to build the project:
+
+```console
+$ dune build
+```
+
+3. Dune will compile the source files and generate the necessary executables.
+
+## Running the project
+
+1. Change into the **root** directory of your project.
+2. Run the following command to run the main executable:
+
+```console
+$ dune exec ./bin/your-executable.exe
+```
+> Replace `your-executable.exe` with the actual name of your executable.
+
+## Adding a library to project
+
+1. First, make sure you have the required library installed. You can use the following command to install a library using Opam:
+
+```console
+$ opam install library-name
+```
+
+2. Open the `dune` file in your project's root directory.
+3. Add the following line to the `(library ...)` section to include the library:
+
+```dune
+(libraries library-name)
+```
+
+4. Replace `library-name` with the actual name of the library you want to add.
+5. Save and close the `dune` file.
+6. Rebuild the project using the following command:
+
+```console
+$ dune build
+```
+
+7. The added library should now be available for use in your project.

--- a/tech/languages/ocaml/dune.md
+++ b/tech/languages/ocaml/dune.md
@@ -10,7 +10,9 @@ Dune is a build system for OCaml. It provides a comprehensive and uniform interf
 
 ## Install
 
-You can install Dune with OPAM that we installed in the enviroment setup. For do it just run:
+You can install Dune with OPAM that we installed in the enviroment setup.
+
+To install Dune using OPAM run:
 
 ```console
 $ opam install dune

--- a/tech/languages/ocaml/dune.md
+++ b/tech/languages/ocaml/dune.md
@@ -26,7 +26,7 @@ $ opam install dune
 $ mkdir yourprojectname
 ```
 
-2. Change into the new directory and run the following command to initialize a Dune project:
+2. To initialize a Dune project change into the new directory and run the following command:
 
 ```console
 $ cd yourprojectname


### PR DESCRIPTION
I would like to propose the addition of a tutorial on Dune, the OCaml build system, to the Fedora Developer Portal.

Dune is a fast and flexible build system for OCaml that has gained popularity among OCaml developers. It provides a uniform interface for building, testing, and installing OCaml projects, and helps manage dependencies between packages.

Adding a tutorial on Dune to the Fedora Developer Portal would be highly beneficial for OCaml developers who are new to the language and want to get started with building projects. The tutorial would provide a step-by-step guide on how to install Dune, start a new project, build the project, and run it, as well as how to add a library to a Dune project.

Inclusion of this tutorial would make the Fedora Developer Portal a more comprehensive resource for OCaml developers and help to attract new users to Fedora. I believe it would be a valuable addition to the existing resources on the portal.

I have included the tutorial in this pull request for your review. Please let me know if you have any questions or concerns. I look forward to your feedback.

Thank you for your time and consideration.