### PR TITLE
Update instructions in ruby-installation.md

### DIFF
--- a/tech/languages/ruby/ruby-installation.md
+++ b/tech/languages/ruby/ruby-installation.md
@@ -62,7 +62,7 @@ RUBYPICK=_jruby_
 The first step is to install dependencies for Ruby.
 
 ```
-sudo dnf install git-core zlib zlib-devel gcc-c++ patch readline readline-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel
+sudo dnf install git-core zlib zlib-devel gcc-c++ patch readline readline-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel perl-FindBin
 ```
 
 Install rbenv
@@ -84,8 +84,8 @@ exec $SHELL
 Install Ruby
 
 ```
-rbenv install 2.6.6
-rbenv global 2.6.6
+rbenv install 2.7.8
+rbenv global 2.7.8
 ruby -v
 
 ```


### PR DESCRIPTION
For Fedora 38, also package perl-FindBin is needed to successfully install ruby with rbenv.

Also, updating the rbenv example to ruby 2.7.8 Ruby 2.7.8 is the latest and last version of ruby major version 2. Ruby 2 is now end of life.