### PR TITLE
Update rails.md to use packaged rbenv

### DIFF
--- a/start/sw/web-app/rails.md
+++ b/start/sw/web-app/rails.md
@@ -6,33 +6,24 @@ order: 6
 
 # Installing Ruby and Rails with rbenv
 
-The first step is to install dependencies for Ruby.
+The first step is to install dependencies for Ruby and rbenv.
 
 ```
-sudo dnf install git-core zlib zlib-devel gcc-c++ patch readline readline-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel
+sudo dnf install git-core zlib zlib-devel gcc-c++ patch readline-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison libcurl-devel sqlite-devel rbenv rbenv-build-rbenv
 ```
 
-Install rbenv
+Then configure your shell to enable rbenv:
 
 ```
-cd
-git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
-exec $SHELL
-
-git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
-exec $SHELL
 ```
 
-Install Ruby
+Install a Ruby version, such as 3.1.2. See `rbenv install --list` for available versions.
 
 ```
-rbenv install 2.6.6
-rbenv global 2.6.6
+rbenv install 3.1.2
+rbenv global 3.1.2
 ruby -v
 
 ```
@@ -40,12 +31,6 @@ Use this command if you do not want rubygems to install the documentation for ea
 
 ```
 echo "gem: --no-ri --no-rdoc" > ~/.gemrc
-```
-
-Install bundler
-
-```
-gem install bundler
 ```
 
 Whenever you install a new version of Ruby or a gem, you should run the rehash sub-command. This will make rails executables known to rbenv, which will allow us to run those executables:
@@ -59,14 +44,13 @@ rbenv rehash
 Rails depends on a Javascript runtime, install nodejs.
 
 ```
-sudo dnf install epel-release
 sudo dnf install nodejs
 ```
 
 And now install Rails
 
 ```
-gem install rails -v 4.2.6
+gem install rails -v 7.1.2
 ```
 ```
 rbenv rehash


### PR DESCRIPTION
This updates the document to use the packaged rbenv instead of installing it from git. It also updates the version numbers to be more recent.

epel-release installation is dropped since that only applies to Enterprise Linux. Even there EL8+ has nodejs packaged.