### PR TITLE
Haskell platform page was deprecated upstream, Fedora still provides it.

### DIFF
--- a/tech/languages/haskell/haskell-installation.md
+++ b/tech/languages/haskell/haskell-installation.md
@@ -53,9 +53,9 @@ in general.
 # The Haskell Platform
 
 Another option is to install the
-[Haskell Platform](https://www.haskell.org/platform/), which provides `ghc` and
-`ghci` as above, but also includes a plethora of useful Haskell libraries and
-utilities to help kickstart your Haskell programming experience.
+[Haskell Platform](https://src.fedoraproject.org/rpms/haskell-platform) package,
+which provides `ghc` and `ghci` as above, but also includes a plethora of useful Haskell libraries
+and utilities to help kickstart your Haskell programming experience.
 
 The Haskell Platform also includes Cabal, which aids in the packaging,
 distribution, and installation of Haskell libraries and applications.


### PR DESCRIPTION
The haskell platform package, while not seemingly available upstream is still in Fedora with the same spirit of providing full environment. According to waybackmachine for the page of 2021, the page only provided the `dnf install haskell-platform`.

That package is still well maintained, so let's point there for now.

Fixes: https://github.com/developer-portal/content/issues/493