### PR TITLE
Update MongoDB page

### DIFF
--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -33,27 +33,25 @@ $ sudo nano /etc/yum.repos.d/mongodb-org-6.0.repo
 Insert this content inside the mongodb-org-*release_series*.repo file, edit the *release_series* in the filename and the baseurl and gpgkey fields URLs if you want to install another version.
 
 ```
-[mongodb-org-6.0]
+[mongodb-org-7.0]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/6.0/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-6.0.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-7.0.asc
 ```
 
-Now you can install with dnf
+Now you can install with dnf. Note that we install the dependencies separately, otherwise mongosh throws an error due to mismatched openssl versions.
 
 ```console
-$ sudo dnf install mongodb-org
+$ sudo dnf install mongodb-org mongodb-mongosh-shared-openssl3 openssl mongodb-org-database-tools-extra mongodb-database-tools mongodb-org-tools mongodb-org-server mongodb-org-mongos mongodb-org-database
 ```
-
-Currently some packages do not install, however those packages do not affect the functionality of MongoDB.
 
 **Warning:** MongoDB does not guarantee compatibility with Fedora Linux, so newer MongoDB server packages might fail to install. [See MongoDB issue ticket SERVER-58871](https://jira.mongodb.org/browse/SERVER-58870).
 
 ## Enable MongoDB services
 
-To enable and start MongoDB service run:
+Restart the computer and then enable and start MongoDB service by running the command:
 
 ```console
 $ sudo systemctl enable mongod.service
@@ -77,6 +75,24 @@ Connecting to:		mongodb://<address:port>
 Using MongoDB:		6.0.8
 ```
 
-## MongoDB GUI (not tested)
+## MongoDB Compass
 
-[MongoDB Admin](https://github.com/hatamiarash7/MongoDB_Admin/wiki/1.-Getting-Start) is a Cross Platform GUI.
+[MongoDB Compass](https://www.mongodb.com/products/tools/compass) is a GUI for interfacing with MongoDB.
+
+To install Compass, run the command to retrieve the files using wget.
+
+```console
+$ wget https://downloads.mongodb.com/compass/mongodb-compass-1.43.0.x86_64.rpm
+```
+
+Then, install the files using yum.
+
+```console
+$ sudo yum install mongodb-compass-1.43.0.x86_64.rpm
+```
+
+Now, run the GUI from the terminal using the command:
+
+```console
+$ mongodb-compass
+```

--- a/tech/database/mongodb/about.md
+++ b/tech/database/mongodb/about.md
@@ -27,7 +27,7 @@ latter is typically used for repository configuration and takes precedence over 
 Create a file mongodb-org-*release_series*.repo
 
 ```console
-$ sudo nano /etc/yum.repos.d/mongodb-org-6.0.repo
+$ sudo nano /etc/yum.repos.d/mongodb-org-7.0.repo
 ```
 
 Insert this content inside the mongodb-org-*release_series*.repo file, edit the *release_series* in the filename and the baseurl and gpgkey fields URLs if you want to install another version.
@@ -41,7 +41,8 @@ enabled=1
 gpgkey=https://www.mongodb.org/static/pgp/server-7.0.asc
 ```
 
-Now you can install with dnf. Note that we install the dependencies separately, otherwise mongosh throws an error due to mismatched openssl versions.
+Now you can install with dnf. We install all the dependencies separately because by default the `mongodb-org` package is dependent on `mongodb-mongosh`. This package has a dependency on static openssl installed with nodeJS which differs from the version of openssl installed on fedora by default. Therefore, we install `mongodb-mongosh-shared-openssl3` which links with the native openssl library which is openssl 3.x.x.
+([See tickets MONGOSH-1231 and MONGOSH-1270 for more information.](https://jira.mongodb.org/browse/MONGOSH-1270?jql=text%20~%20%22mongodb-mongosh-shared-openssl3%22))
 
 ```console
 $ sudo dnf install mongodb-org mongodb-mongosh-shared-openssl3 openssl mongodb-org-database-tools-extra mongodb-database-tools mongodb-org-tools mongodb-org-server mongodb-org-mongos mongodb-org-database
@@ -96,3 +97,4 @@ Now, run the GUI from the terminal using the command:
 ```console
 $ mongodb-compass
 ```
+[Source](https://www.mongodb.com/docs/compass/current/install/)


### PR DESCRIPTION
updated the MongoDB page with the following changes.

1. updated the MongoDB version being installed from 6.0 to 7.0
2. update the installation step to use the correct version of mongosh.
3. added a guide to install MongoDB Compass which is the official GUI for MongoDB