### PR TITLE
Update .NET docs, replacing .NET 6 with .NET 9

### DIFF
--- a/tech/languages/dotnet/about.md
+++ b/tech/languages/dotnet/about.md
@@ -3,7 +3,7 @@ title: .NET Platforms
 subsection: dotnet
 section: tech-languages
 order: 1
-version: 7.8.4
+version: 7.8.5
 description: ".NET and Mono are open-source .NET platforms. .NET applications are developed using the C#, F# and VB.NET programming languages."
 permalink: /tech/languages/csharp/dotnet-installation.html
 ---
@@ -14,13 +14,13 @@ permalink: /tech/languages/csharp/dotnet-installation.html
 
 [.NET](https://docs.microsoft.com/en-us/dotnet/core/) is a general-purpose, modular, cross-platform and open-source development Platform.
 
-.NET 8 and .NET 6 are available in all supported versions of Fedora. Installing an SDK can be done with a simple
+.NET 9 and .NET 6 are available in all supported versions of Fedora. Installing an SDK can be done with a simple
 
 ```
 $ sudo dnf install dotnet-sdk-x.y
 ```
 
-Where `x.y` is a .NET version number, like `8.0` or `6.0`.
+Where `x.y` is a .NET version number, like `9.0` or `8.0`.
 
 It is not advised to mix these packages with those provided by Microsoft. Please disable any other repositories providing dotnet before installing these. If you run into any errors that refer to `/usr/share/dotnet` or a missing `libhostfxr.so` see [troubleshoot .NET errors related to missing files on Linux](https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup) which describes how to fix the errors.
 

--- a/tech/languages/dotnet/about.md
+++ b/tech/languages/dotnet/about.md
@@ -14,7 +14,7 @@ permalink: /tech/languages/csharp/dotnet-installation.html
 
 [.NET](https://docs.microsoft.com/en-us/dotnet/core/) is a general-purpose, modular, cross-platform and open-source development Platform.
 
-.NET 9 and .NET 6 are available in all supported versions of Fedora. Installing an SDK can be done with a simple
+.NET 9 and .NET 8 are available in all supported versions of Fedora. Installing an SDK can be done with a simple
 
 ```
 $ sudo dnf install dotnet-sdk-x.y

--- a/tech/languages/dotnet/dotnetcore.md
+++ b/tech/languages/dotnet/dotnetcore.md
@@ -2,7 +2,7 @@
 title: .NET
 subsection: dotnet
 order: 2
-version: 7.8.4
+version: 7.8.5
 ---
 
 ## .NET Installation
@@ -29,6 +29,28 @@ To install runtime only, for example to merely deploy an already built (non ASP.
 $ sudo dnf install dotnet-runtime-x.y
 ```
 
+### .NET 9
+
+.NET 9 is a Standard Term Support release and will reach its End of Life in May 2026.
+
+Install the .NET 9 SDK:
+
+```
+$ sudo dnf install dotnet-sdk-9.0
+```
+
+Install the ASP.NET Core 9 Runtime:
+
+```
+$ sudo dnf install aspnetcore-runtime-9.0
+```
+
+Install the .NET 9 Runtime:
+
+```
+$ sudo dnf install dotnet-runtime-9.0
+```
+
 ### .NET 8
 
 .NET 8 is a Long Term Support release and will reach its End of Life in Nov 2026.
@@ -51,27 +73,6 @@ Install the .NET 8 Runtime:
 $ sudo dnf install dotnet-runtime-8.0
 ```
 
-### .NET 6
-
-.NET 6 is a Long Term Support release and will reach its End of Life in November 2024.
-
-Install the .NET 6 SDK:
-
-```
-$ sudo dnf install dotnet-sdk-6.0
-```
-
-Install the ASP.NET Core 6 Runtime:
-
-```
-$ sudo dnf install aspnetcore-runtime-6.0
-```
-
-Install the .NET 6 Runtime:
-
-```
-$ sudo dnf install dotnet-runtime-6.0
-```
 
 ### Preview versions
 


### PR DESCRIPTION
Removes .NET 6 and adds .NET 9. Fixes #549.