### PR TITLE
Update Python versions and remove old notice

### DIFF
--- a/tech/languages/python/fastapi-installation.md
+++ b/tech/languages/python/fastapi-installation.md
@@ -12,8 +12,6 @@ order: 5
 
 Fedora includes a `python3-fastapi` package that you can install and import.
 
-**Warning:** The `python-fastapi` package [will be removed from Fedora in Fedora 37](https://src.fedoraproject.org/rpms/python-fastapi/c/584bd1fef19c95576a4511a3dae77b4d35136258?branch=f37).
-
 However, unless you are developing or packaging an application for Fedora, it is more useful to install FastAPI as a third-party package inside a *virtual environment*.
 This will keep your project separate from your system, giving you more freedom in choosing additional libraries and their versions, and easing collaboration with people who aren't using Fedora yet.
 

--- a/tech/languages/python/multiple-pythons.md
+++ b/tech/languages/python/multiple-pythons.md
@@ -15,29 +15,28 @@ Fedora includes all Python versions which are [supported upstream](https://devgu
 At the time of this writing, Fedora has the following Pythons
 ready for you in the repositories:
  
+ * CPython 3.14
+ * CPython 3.13 (System `python3` on Fedora 41)
+ * CPython 3.12 (System `python3` on Fedora 40)
  * CPython 3.11
  * CPython 3.10
  * CPython 3.9
  * CPython 3.8
- * CPython 3.7
  * CPython 3.6
- * CPython 2.7
- * PyPy 2
- * PyPy 3.7
- * PyPy 3.8
+ * PyPy 2.7
  * PyPy 3.9
+ * PyPy 3.10
  * MicroPython
 
 Quite a nest, isn't it?
 You can install them like this:
 
 ```console
+$ sudo dnf install python3.11  # to get CPython 3.11
 $ sudo dnf install python3.9  # to get CPython 3.9
 $ sudo dnf install python3.8  # to get CPython 3.8
-$ sudo dnf install python3.7  # to get CPython 3.7
 $ sudo dnf install python3.6  # to get CPython 3.6
-$ sudo dnf install python2.7  # to get CPython 2.7
-$ sudo dnf install pypy2 pypy3.9 python3.10  # to get more at once
+$ sudo dnf install pypy pypy3.9 python3.10  # to get more at once
 ```
 
 After that, you can run an interactive console or your script with, let's say,


### PR DESCRIPTION
I happened to glance at the Python documentation and noticed it was outdated.

I've tried to fix those things which I have noticed, specifically:

- The list of available Python versions
- The old deprecation notice for fastapi; it is still packaged in Fedora