### PR TITLE
Fixes Flathub app link 404 error

### DIFF
--- a/deployment/flatpak/flatpak-usage.md
+++ b/deployment/flatpak/flatpak-usage.md
@@ -70,5 +70,5 @@ $ flatpak run org.gnome.Polari
 
 ## Further Reading
 
-* [Flathub Applications](https://flathub.org/apps.html)
+* [Flathub Applications](https://flathub.org/)
 * [Fedora Flatpaks](https://docs.fedoraproject.org/en-US/flatpak/tutorial/)


### PR DESCRIPTION
This PR is a quick fix for a currently broken link on the [Flatpak Usage page](https://developer.fedoraproject.org/deployment/flatpak/flatpak-usage.html), for "Flathub Applications."

- Original URL (404s): https://flathub.org/apps.html
- New URL: https://flathub.org/

Looks like the app search is now built into the homepage on Flathub. 

A similar URL, `https://flathub.org/apps/`, will also redirect to `https://flathub.org/`, hence my decision to use that URL.